### PR TITLE
Updates on the toppings for lg_geolassets project.

### DIFF
--- a/lg_geolassets_v2/layerstyle/assetformatitem.qml
+++ b/lg_geolassets_v2/layerstyle/assetformatitem.qml
@@ -1,262 +1,270 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="Fields|Forms" version="3.25.0-Master">
+<qgis readOnly="1" styleCategories="LayerConfiguration|Fields|Forms" version="3.24.3-Tisler">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id">
+    <field name="T_Id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_basket">
+    <field name="T_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="&quot;topic&quot; = 'GeolAssetsCatalogues_V2.Catalogues' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" type="QString" name="ReferencedLayerId"/>
-            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="assetformatitem_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; = 'GeolAssetsCatalogues_V2.Catalogues' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="Relation" type="QString" value="assetkinditem_T_basket_T_ILI2DB_BASKET_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_Ili_Tid">
+    <field name="T_Ili_Tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="acode">
+    <field name="acode" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="geolcode" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="aname" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="aname_de" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="geolcode">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname_de">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname_fr">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname_rm">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname_it">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname_en">
+    <field name="aname_fr" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription">
+    <field name="aname_rm" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription_de">
+    <field name="aname_it" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription_fr">
+    <field name="aname_en" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription_rm">
+    <field name="adescription" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription_it">
+    <field name="adescription_de" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="adescription_fr" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="adescription_rm" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription_en">
+    <field name="adescription_it" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="mime">
+    <field name="adescription_en" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="mime" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="issuperitem">
+    <field name="issuperitem" configurationFlags="None">
       <editWidget type="CheckBox">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="isuseable">
+    <field name="isuseable" configurationFlags="None">
       <editWidget type="CheckBox">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_statusworkitem">
+    <field name="parent_statusworkitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_natrelitem">
+    <field name="parent_assetkinditem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_languageitem">
+    <field name="parent_languageitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_legaldocitem">
+    <field name="parent_natrelitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_assetkinditem">
+    <field name="parent_mancatlabelitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_statusassetuseitem">
+    <field name="parent_autocatlabelitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_autoobjectcatitem">
+    <field name="parent_contactkinditem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_contactkinditem">
+    <field name="parent_assetformatitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_assetformatitem">
+    <field name="parent_statusassetuseitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_mancatlabelitem">
+    <field name="parent_legaldocitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_autocatlabelitem">
+    <field name="parent_geomqualityitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_pubchannelitem">
+    <field name="parent_autoobjectcatitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_geomqualityitem">
+    <field name="parent_pubchannelitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
@@ -265,39 +273,39 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="T_Id" index="0" name=""/>
-    <alias field="T_basket" index="1" name=""/>
-    <alias field="T_Ili_Tid" index="2" name=""/>
-    <alias field="acode" index="3" name="Code"/>
-    <alias field="geolcode" index="4" name="GeolCode"/>
-    <alias field="aname" index="5" name="Name"/>
-    <alias field="aname_de" index="6" name=""/>
-    <alias field="aname_fr" index="7" name=""/>
-    <alias field="aname_rm" index="8" name=""/>
-    <alias field="aname_it" index="9" name=""/>
-    <alias field="aname_en" index="10" name=""/>
-    <alias field="adescription" index="11" name="Description"/>
-    <alias field="adescription_de" index="12" name=""/>
-    <alias field="adescription_fr" index="13" name=""/>
-    <alias field="adescription_rm" index="14" name=""/>
-    <alias field="adescription_it" index="15" name=""/>
-    <alias field="adescription_en" index="16" name=""/>
-    <alias field="mime" index="17" name="MIME"/>
-    <alias field="issuperitem" index="18" name="IsSuperItem"/>
-    <alias field="isuseable" index="19" name="IsUseable"/>
-    <alias field="parent_statusworkitem" index="20" name="Parent"/>
-    <alias field="parent_natrelitem" index="21" name="Parent"/>
-    <alias field="parent_languageitem" index="22" name="Parent"/>
-    <alias field="parent_legaldocitem" index="23" name="Parent"/>
-    <alias field="parent_assetkinditem" index="24" name="Parent"/>
-    <alias field="parent_statusassetuseitem" index="25" name="Parent"/>
-    <alias field="parent_autoobjectcatitem" index="26" name="Parent"/>
-    <alias field="parent_contactkinditem" index="27" name="Parent"/>
-    <alias field="parent_assetformatitem" index="28" name="Parent"/>
-    <alias field="parent_mancatlabelitem" index="29" name="Parent"/>
-    <alias field="parent_autocatlabelitem" index="30" name="Parent"/>
-    <alias field="parent_pubchannelitem" index="31" name="Parent"/>
-    <alias field="parent_geomqualityitem" index="32" name="Parent"/>
+    <alias name="" field="T_Id" index="0"/>
+    <alias name="" field="T_basket" index="1"/>
+    <alias name="" field="T_Ili_Tid" index="2"/>
+    <alias name="Code" field="acode" index="3"/>
+    <alias name="GeolCode" field="geolcode" index="4"/>
+    <alias name="Name" field="aname" index="5"/>
+    <alias name="" field="aname_de" index="6"/>
+    <alias name="" field="aname_fr" index="7"/>
+    <alias name="" field="aname_rm" index="8"/>
+    <alias name="" field="aname_it" index="9"/>
+    <alias name="" field="aname_en" index="10"/>
+    <alias name="Description" field="adescription" index="11"/>
+    <alias name="" field="adescription_de" index="12"/>
+    <alias name="" field="adescription_fr" index="13"/>
+    <alias name="" field="adescription_rm" index="14"/>
+    <alias name="" field="adescription_it" index="15"/>
+    <alias name="" field="adescription_en" index="16"/>
+    <alias name="MIME" field="mime" index="17"/>
+    <alias name="IsSuperItem" field="issuperitem" index="18"/>
+    <alias name="IsUseable" field="isuseable" index="19"/>
+    <alias name="Parent" field="parent_statusworkitem" index="20"/>
+    <alias name="Parent" field="parent_assetkinditem" index="21"/>
+    <alias name="Parent" field="parent_languageitem" index="22"/>
+    <alias name="Parent" field="parent_natrelitem" index="23"/>
+    <alias name="Parent" field="parent_mancatlabelitem" index="24"/>
+    <alias name="Parent" field="parent_autocatlabelitem" index="25"/>
+    <alias name="Parent" field="parent_contactkinditem" index="26"/>
+    <alias name="Parent" field="parent_assetformatitem" index="27"/>
+    <alias name="Parent" field="parent_statusassetuseitem" index="28"/>
+    <alias name="Parent" field="parent_legaldocitem" index="29"/>
+    <alias name="Parent" field="parent_geomqualityitem" index="30"/>
+    <alias name="Parent" field="parent_autoobjectcatitem" index="31"/>
+    <alias name="Parent" field="parent_pubchannelitem" index="32"/>
   </aliases>
   <defaults>
     <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
@@ -321,88 +329,88 @@
     <default field="issuperitem" expression="" applyOnUpdate="0"/>
     <default field="isuseable" expression="" applyOnUpdate="0"/>
     <default field="parent_statusworkitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_natrelitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_languageitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_legaldocitem" expression="" applyOnUpdate="0"/>
     <default field="parent_assetkinditem" expression="" applyOnUpdate="0"/>
-    <default field="parent_statusassetuseitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_autoobjectcatitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_contactkinditem" expression="" applyOnUpdate="0"/>
-    <default field="parent_assetformatitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_languageitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_natrelitem" expression="" applyOnUpdate="0"/>
     <default field="parent_mancatlabelitem" expression="" applyOnUpdate="0"/>
     <default field="parent_autocatlabelitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_pubchannelitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_contactkinditem" expression="" applyOnUpdate="0"/>
+    <default field="parent_assetformatitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_statusassetuseitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_legaldocitem" expression="" applyOnUpdate="0"/>
     <default field="parent_geomqualityitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_autoobjectcatitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_pubchannelitem" expression="" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" notnull_strength="1" field="T_Id" exp_strength="0" constraints="3"/>
-    <constraint unique_strength="0" notnull_strength="1" field="T_basket" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="T_Ili_Tid" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="1" field="acode" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="geolcode" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname_de" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname_fr" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname_rm" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname_it" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname_en" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription_de" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription_fr" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription_rm" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription_it" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription_en" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="mime" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="1" field="issuperitem" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="1" field="isuseable" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_statusworkitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_natrelitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_languageitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_legaldocitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_assetkinditem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_statusassetuseitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_autoobjectcatitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_contactkinditem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_assetformatitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_mancatlabelitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_autocatlabelitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_pubchannelitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_geomqualityitem" exp_strength="0" constraints="0"/>
+    <constraint constraints="3" field="T_Id" unique_strength="1" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="1" field="T_basket" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="T_Ili_Tid" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="1" field="acode" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="geolcode" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_de" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_fr" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_rm" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_it" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_en" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_de" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_fr" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_rm" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_it" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_en" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="mime" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="1" field="issuperitem" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="1" field="isuseable" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="parent_statusworkitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_assetkinditem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_languageitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_natrelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_mancatlabelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_autocatlabelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_contactkinditem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_assetformatitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_statusassetuseitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_legaldocitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_geomqualityitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_autoobjectcatitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_pubchannelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="T_Id" desc="" exp=""/>
-    <constraint field="T_basket" desc="" exp=""/>
-    <constraint field="T_Ili_Tid" desc="" exp=""/>
-    <constraint field="acode" desc="" exp=""/>
-    <constraint field="geolcode" desc="" exp=""/>
-    <constraint field="aname" desc="" exp=""/>
-    <constraint field="aname_de" desc="" exp=""/>
-    <constraint field="aname_fr" desc="" exp=""/>
-    <constraint field="aname_rm" desc="" exp=""/>
-    <constraint field="aname_it" desc="" exp=""/>
-    <constraint field="aname_en" desc="" exp=""/>
-    <constraint field="adescription" desc="" exp=""/>
-    <constraint field="adescription_de" desc="" exp=""/>
-    <constraint field="adescription_fr" desc="" exp=""/>
-    <constraint field="adescription_rm" desc="" exp=""/>
-    <constraint field="adescription_it" desc="" exp=""/>
-    <constraint field="adescription_en" desc="" exp=""/>
-    <constraint field="mime" desc="" exp=""/>
-    <constraint field="issuperitem" desc="" exp=""/>
-    <constraint field="isuseable" desc="" exp=""/>
-    <constraint field="parent_statusworkitem" desc="" exp=""/>
-    <constraint field="parent_natrelitem" desc="" exp=""/>
-    <constraint field="parent_languageitem" desc="" exp=""/>
-    <constraint field="parent_legaldocitem" desc="" exp=""/>
-    <constraint field="parent_assetkinditem" desc="" exp=""/>
-    <constraint field="parent_statusassetuseitem" desc="" exp=""/>
-    <constraint field="parent_autoobjectcatitem" desc="" exp=""/>
-    <constraint field="parent_contactkinditem" desc="" exp=""/>
-    <constraint field="parent_assetformatitem" desc="" exp=""/>
-    <constraint field="parent_mancatlabelitem" desc="" exp=""/>
-    <constraint field="parent_autocatlabelitem" desc="" exp=""/>
-    <constraint field="parent_pubchannelitem" desc="" exp=""/>
-    <constraint field="parent_geomqualityitem" desc="" exp=""/>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="T_Ili_Tid" desc=""/>
+    <constraint exp="" field="acode" desc=""/>
+    <constraint exp="" field="geolcode" desc=""/>
+    <constraint exp="" field="aname" desc=""/>
+    <constraint exp="" field="aname_de" desc=""/>
+    <constraint exp="" field="aname_fr" desc=""/>
+    <constraint exp="" field="aname_rm" desc=""/>
+    <constraint exp="" field="aname_it" desc=""/>
+    <constraint exp="" field="aname_en" desc=""/>
+    <constraint exp="" field="adescription" desc=""/>
+    <constraint exp="" field="adescription_de" desc=""/>
+    <constraint exp="" field="adescription_fr" desc=""/>
+    <constraint exp="" field="adescription_rm" desc=""/>
+    <constraint exp="" field="adescription_it" desc=""/>
+    <constraint exp="" field="adescription_en" desc=""/>
+    <constraint exp="" field="mime" desc=""/>
+    <constraint exp="" field="issuperitem" desc=""/>
+    <constraint exp="" field="isuseable" desc=""/>
+    <constraint exp="" field="parent_statusworkitem" desc=""/>
+    <constraint exp="" field="parent_assetkinditem" desc=""/>
+    <constraint exp="" field="parent_languageitem" desc=""/>
+    <constraint exp="" field="parent_natrelitem" desc=""/>
+    <constraint exp="" field="parent_mancatlabelitem" desc=""/>
+    <constraint exp="" field="parent_autocatlabelitem" desc=""/>
+    <constraint exp="" field="parent_contactkinditem" desc=""/>
+    <constraint exp="" field="parent_assetformatitem" desc=""/>
+    <constraint exp="" field="parent_statusassetuseitem" desc=""/>
+    <constraint exp="" field="parent_legaldocitem" desc=""/>
+    <constraint exp="" field="parent_geomqualityitem" desc=""/>
+    <constraint exp="" field="parent_autoobjectcatitem" desc=""/>
+    <constraint exp="" field="parent_pubchannelitem" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <editform tolerant="1"></editform>
@@ -411,28 +419,36 @@
   <editforminitfilepath></editforminitfilepath>
   <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
-QGIS-Formulare können eine Python-Funktion haben,, die aufgerufen wird, wenn sich das Formular öffnet
+QGIS forms can have a Python function that is called when the form is
+opened.
 
-Diese Funktion kann verwendet werden um dem Formular Extralogik hinzuzufügen.
+Use this function to add extra logic to your forms.
 
-Der Name der Funktion wird im Feld "Python Init-Function" angegeben
-Ein Beispiel folgt:
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
 """
 from qgis.PyQt.QtWidgets import QWidget
 
 def my_form_open(dialog, layer, feature):
-	geom = feature.geometry()
-	control = dialog.findChild(QWidget, "MyLineEdit")
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField showLabel="1" name="acode" index="3"/>
-    <attributeEditorField showLabel="1" name="geolcode" index="4"/>
-    <attributeEditorField showLabel="1" name="aname" index="5"/>
-    <attributeEditorField showLabel="1" name="aname_de" index="6"/>
-    <attributeEditorField showLabel="1" name="adescription" index="11"/>
-    <attributeEditorField showLabel="1" name="adescription_de" index="12"/>
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="English" columnCount="1" groupBox="1" showLabel="1">
+      <attributeEditorField name="aname_en" index="10" showLabel="0"/>
+      <attributeEditorField name="adescription_en" index="16" showLabel="0"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="French" columnCount="1" groupBox="1" showLabel="1">
+      <attributeEditorField name="aname_fr" index="7" showLabel="0"/>
+      <attributeEditorField name="adescription_fr" index="13" showLabel="0"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="German" columnCount="1" groupBox="1" showLabel="1">
+      <attributeEditorField name="aname_de" index="6" showLabel="0"/>
+      <attributeEditorField name="adescription_de" index="12" showLabel="0"/>
+    </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
     <field name="T_Id" editable="1"/>
@@ -440,15 +456,15 @@ def my_form_open(dialog, layer, feature):
     <field name="T_basket" editable="1"/>
     <field name="acode" editable="1"/>
     <field name="adescription" editable="1"/>
-    <field name="adescription_de" editable="1"/>
-    <field name="adescription_en" editable="1"/>
-    <field name="adescription_fr" editable="1"/>
+    <field name="adescription_de" editable="0"/>
+    <field name="adescription_en" editable="0"/>
+    <field name="adescription_fr" editable="0"/>
     <field name="adescription_it" editable="1"/>
     <field name="adescription_rm" editable="1"/>
     <field name="aname" editable="1"/>
-    <field name="aname_de" editable="1"/>
+    <field name="aname_de" editable="0"/>
     <field name="aname_en" editable="1"/>
-    <field name="aname_fr" editable="1"/>
+    <field name="aname_fr" editable="0"/>
     <field name="aname_it" editable="1"/>
     <field name="aname_rm" editable="1"/>
     <field name="geolcode" editable="1"/>
@@ -470,76 +486,77 @@ def my_form_open(dialog, layer, feature):
     <field name="parent_statusworkitem" editable="1"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="T_Id"/>
-    <field labelOnTop="0" name="T_Ili_Tid"/>
-    <field labelOnTop="0" name="T_basket"/>
-    <field labelOnTop="0" name="acode"/>
-    <field labelOnTop="0" name="adescription"/>
-    <field labelOnTop="0" name="adescription_de"/>
-    <field labelOnTop="0" name="adescription_en"/>
-    <field labelOnTop="0" name="adescription_fr"/>
-    <field labelOnTop="0" name="adescription_it"/>
-    <field labelOnTop="0" name="adescription_rm"/>
-    <field labelOnTop="0" name="aname"/>
-    <field labelOnTop="0" name="aname_de"/>
-    <field labelOnTop="0" name="aname_en"/>
-    <field labelOnTop="0" name="aname_fr"/>
-    <field labelOnTop="0" name="aname_it"/>
-    <field labelOnTop="0" name="aname_rm"/>
-    <field labelOnTop="0" name="geolcode"/>
-    <field labelOnTop="0" name="issuperitem"/>
-    <field labelOnTop="0" name="isuseable"/>
-    <field labelOnTop="0" name="mime"/>
-    <field labelOnTop="0" name="parent_assetformatitem"/>
-    <field labelOnTop="0" name="parent_assetkinditem"/>
-    <field labelOnTop="0" name="parent_autocatlabelitem"/>
-    <field labelOnTop="0" name="parent_autoobjectcatitem"/>
-    <field labelOnTop="0" name="parent_contactkinditem"/>
-    <field labelOnTop="0" name="parent_geomqualityitem"/>
-    <field labelOnTop="0" name="parent_languageitem"/>
-    <field labelOnTop="0" name="parent_legaldocitem"/>
-    <field labelOnTop="0" name="parent_mancatlabelitem"/>
-    <field labelOnTop="0" name="parent_natrelitem"/>
-    <field labelOnTop="0" name="parent_pubchannelitem"/>
-    <field labelOnTop="0" name="parent_statusassetuseitem"/>
-    <field labelOnTop="0" name="parent_statusworkitem"/>
+    <field name="T_Id" labelOnTop="0"/>
+    <field name="T_Ili_Tid" labelOnTop="0"/>
+    <field name="T_basket" labelOnTop="0"/>
+    <field name="acode" labelOnTop="0"/>
+    <field name="adescription" labelOnTop="0"/>
+    <field name="adescription_de" labelOnTop="0"/>
+    <field name="adescription_en" labelOnTop="0"/>
+    <field name="adescription_fr" labelOnTop="0"/>
+    <field name="adescription_it" labelOnTop="0"/>
+    <field name="adescription_rm" labelOnTop="0"/>
+    <field name="aname" labelOnTop="0"/>
+    <field name="aname_de" labelOnTop="0"/>
+    <field name="aname_en" labelOnTop="0"/>
+    <field name="aname_fr" labelOnTop="0"/>
+    <field name="aname_it" labelOnTop="0"/>
+    <field name="aname_rm" labelOnTop="0"/>
+    <field name="geolcode" labelOnTop="0"/>
+    <field name="issuperitem" labelOnTop="0"/>
+    <field name="isuseable" labelOnTop="0"/>
+    <field name="mime" labelOnTop="0"/>
+    <field name="parent_assetformatitem" labelOnTop="0"/>
+    <field name="parent_assetkinditem" labelOnTop="0"/>
+    <field name="parent_autocatlabelitem" labelOnTop="0"/>
+    <field name="parent_autoobjectcatitem" labelOnTop="0"/>
+    <field name="parent_contactkinditem" labelOnTop="0"/>
+    <field name="parent_geomqualityitem" labelOnTop="0"/>
+    <field name="parent_languageitem" labelOnTop="0"/>
+    <field name="parent_legaldocitem" labelOnTop="0"/>
+    <field name="parent_mancatlabelitem" labelOnTop="0"/>
+    <field name="parent_natrelitem" labelOnTop="0"/>
+    <field name="parent_pubchannelitem" labelOnTop="0"/>
+    <field name="parent_statusassetuseitem" labelOnTop="0"/>
+    <field name="parent_statusworkitem" labelOnTop="0"/>
   </labelOnTop>
   <reuseLastValue>
-    <field reuseLastValue="0" name="T_Id"/>
-    <field reuseLastValue="0" name="T_Ili_Tid"/>
-    <field reuseLastValue="0" name="T_basket"/>
-    <field reuseLastValue="0" name="acode"/>
-    <field reuseLastValue="0" name="adescription"/>
-    <field reuseLastValue="0" name="adescription_de"/>
-    <field reuseLastValue="0" name="adescription_en"/>
-    <field reuseLastValue="0" name="adescription_fr"/>
-    <field reuseLastValue="0" name="adescription_it"/>
-    <field reuseLastValue="0" name="adescription_rm"/>
-    <field reuseLastValue="0" name="aname"/>
-    <field reuseLastValue="0" name="aname_de"/>
-    <field reuseLastValue="0" name="aname_en"/>
-    <field reuseLastValue="0" name="aname_fr"/>
-    <field reuseLastValue="0" name="aname_it"/>
-    <field reuseLastValue="0" name="aname_rm"/>
-    <field reuseLastValue="0" name="geolcode"/>
-    <field reuseLastValue="0" name="issuperitem"/>
-    <field reuseLastValue="0" name="isuseable"/>
-    <field reuseLastValue="0" name="mime"/>
-    <field reuseLastValue="0" name="parent_assetformatitem"/>
-    <field reuseLastValue="0" name="parent_assetkinditem"/>
-    <field reuseLastValue="0" name="parent_autocatlabelitem"/>
-    <field reuseLastValue="0" name="parent_autoobjectcatitem"/>
-    <field reuseLastValue="0" name="parent_contactkinditem"/>
-    <field reuseLastValue="0" name="parent_geomqualityitem"/>
-    <field reuseLastValue="0" name="parent_languageitem"/>
-    <field reuseLastValue="0" name="parent_legaldocitem"/>
-    <field reuseLastValue="0" name="parent_mancatlabelitem"/>
-    <field reuseLastValue="0" name="parent_natrelitem"/>
-    <field reuseLastValue="0" name="parent_pubchannelitem"/>
-    <field reuseLastValue="0" name="parent_statusassetuseitem"/>
-    <field reuseLastValue="0" name="parent_statusworkitem"/>
+    <field name="T_Id" reuseLastValue="0"/>
+    <field name="T_Ili_Tid" reuseLastValue="0"/>
+    <field name="T_basket" reuseLastValue="0"/>
+    <field name="acode" reuseLastValue="0"/>
+    <field name="adescription" reuseLastValue="0"/>
+    <field name="adescription_de" reuseLastValue="0"/>
+    <field name="adescription_en" reuseLastValue="0"/>
+    <field name="adescription_fr" reuseLastValue="0"/>
+    <field name="adescription_it" reuseLastValue="0"/>
+    <field name="adescription_rm" reuseLastValue="0"/>
+    <field name="aname" reuseLastValue="0"/>
+    <field name="aname_de" reuseLastValue="0"/>
+    <field name="aname_en" reuseLastValue="0"/>
+    <field name="aname_fr" reuseLastValue="0"/>
+    <field name="aname_it" reuseLastValue="0"/>
+    <field name="aname_rm" reuseLastValue="0"/>
+    <field name="geolcode" reuseLastValue="0"/>
+    <field name="issuperitem" reuseLastValue="0"/>
+    <field name="isuseable" reuseLastValue="0"/>
+    <field name="mime" reuseLastValue="0"/>
+    <field name="parent_assetformatitem" reuseLastValue="0"/>
+    <field name="parent_assetkinditem" reuseLastValue="0"/>
+    <field name="parent_autocatlabelitem" reuseLastValue="0"/>
+    <field name="parent_autoobjectcatitem" reuseLastValue="0"/>
+    <field name="parent_contactkinditem" reuseLastValue="0"/>
+    <field name="parent_geomqualityitem" reuseLastValue="0"/>
+    <field name="parent_languageitem" reuseLastValue="0"/>
+    <field name="parent_legaldocitem" reuseLastValue="0"/>
+    <field name="parent_mancatlabelitem" reuseLastValue="0"/>
+    <field name="parent_natrelitem" reuseLastValue="0"/>
+    <field name="parent_pubchannelitem" reuseLastValue="0"/>
+    <field name="parent_statusassetuseitem" reuseLastValue="0"/>
+    <field name="parent_statusworkitem" reuseLastValue="0"/>
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>
+  <previewExpression>"aname_de"</previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/layerstyle/assetitem.qml
+++ b/lg_geolassets_v2/layerstyle/assetitem.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" version="3.22.7-Białowieża" styleCategories="LayerConfiguration|Fields|Forms">
+<qgis readOnly="0" styleCategories="LayerConfiguration|Fields|Forms|Actions" version="3.24.3-Tisler">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -7,514 +7,536 @@
     <Private>0</Private>
   </flags>
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id">
+    <field name="T_Id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_basket">
+    <field name="T_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" name="AllowAddFeatures" type="bool"/>
-            <Option value="false" name="AllowNULL" type="bool"/>
-            <Option value="false" name="ChainFilters" type="bool"/>
-            <Option value="&quot;topic&quot; = 'LG_GeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" name="FilterExpression" type="QString"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="ChainFilters" type="bool" value="false"/>
+            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; = 'LG_GeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
             <Option name="FilterFields" type="invalid"/>
-            <Option value="false" name="MapIdentification" type="bool"/>
-            <Option value="true" name="OrderByValue" type="bool"/>
-            <Option value="false" name="ReadOnly" type="bool"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" name="ReferencedLayerDataSource" type="QString"/>
-            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" name="ReferencedLayerId" type="QString"/>
-            <Option value="T_ILI2DB_BASKET" name="ReferencedLayerName" type="QString"/>
-            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
-            <Option value="lg_geolssts_v2geolassets_assetitem_T_basket_T_ILI2DB_BASKET_T_Id" name="Relation" type="QString"/>
-            <Option value="false" name="ShowForm" type="bool"/>
-            <Option value="false" name="ShowOpenFormButton" type="bool"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c"/>
+            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="lg_geolssts_v2geolassets_assetitem_T_basket_T_ILI2DB_BASKET_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_Ili_Tid">
+    <field name="T_Ili_Tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="isnatrel">
+    <field name="isnatrel" configurationFlags="None">
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option value="" name="CheckedState" type="QString"/>
-            <Option value="0" name="TextDisplayMethod" type="int"/>
-            <Option value="" name="UncheckedState" type="QString"/>
+            <Option name="CheckedState" type="QString" value=""/>
+            <Option name="TextDisplayMethod" type="int" value="0"/>
+            <Option name="UncheckedState" type="QString" value=""/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="datereceipt">
+    <field name="datereceipt" configurationFlags="None">
       <editWidget type="DateTime">
         <config>
           <Option type="Map">
-            <Option value="true" name="allow_null" type="bool"/>
-            <Option value="true" name="calendar_popup" type="bool"/>
-            <Option value="dd.MM.yyyy" name="display_format" type="QString"/>
-            <Option value="dd.MM.yy" name="field_format" type="QString"/>
-            <Option value="false" name="field_iso_format" type="bool"/>
+            <Option name="allow_null" type="bool" value="true"/>
+            <Option name="calendar_popup" type="bool" value="true"/>
+            <Option name="display_format" type="QString" value="dd.MM.yyyy"/>
+            <Option name="field_format" type="QString" value="dd.MM.yy"/>
+            <Option name="field_iso_format" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="municipality">
+    <field name="municipality" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="url">
+    <field name="url" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="relativepath">
+    <field name="relativepath" configurationFlags="None">
       <editWidget type="ExternalResource">
         <config>
           <Option type="Map">
-            <Option value="0" name="DocumentViewer" type="int"/>
-            <Option value="0" name="DocumentViewerHeight" type="int"/>
-            <Option value="0" name="DocumentViewerWidth" type="int"/>
-            <Option value="true" name="FileWidget" type="bool"/>
-            <Option value="true" name="FileWidgetButton" type="bool"/>
-            <Option value="" name="FileWidgetFilter" type="QString"/>
+            <Option name="DocumentViewer" type="int" value="0"/>
+            <Option name="DocumentViewerHeight" type="int" value="0"/>
+            <Option name="DocumentViewerWidth" type="int" value="0"/>
+            <Option name="FileWidget" type="bool" value="true"/>
+            <Option name="FileWidgetButton" type="bool" value="true"/>
+            <Option name="FileWidgetFilter" type="QString" value=""/>
             <Option name="PropertyCollection" type="Map">
-              <Option value="" name="name" type="QString"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties" type="invalid"/>
-              <Option value="collection" name="type" type="QString"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
-            <Option value="0" name="RelativeStorage" type="int"/>
-            <Option value="" name="StorageAuthConfigId" type="QString"/>
-            <Option value="0" name="StorageMode" type="int"/>
-            <Option value="" name="StorageType" type="QString"/>
-            <Option value="true" name="UseLink" type="bool"/>
+            <Option name="RelativeStorage" type="int" value="0"/>
+            <Option name="StorageAuthConfigId" type="QString" value=""/>
+            <Option name="StorageMode" type="int" value="0"/>
+            <Option name="StorageType" type="QString" value=""/>
+            <Option name="UseLink" type="bool" value="true"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="locationanalog">
+    <field name="locationanalog" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="processor">
+    <field name="processor" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="datelastprocessed">
+    <field name="datelastprocessed" configurationFlags="None">
       <editWidget type="DateTime">
         <config>
           <Option type="Map">
-            <Option value="true" name="allow_null" type="bool"/>
-            <Option value="true" name="calendar_popup" type="bool"/>
-            <Option value="dd.MM.yyyy" name="display_format" type="QString"/>
-            <Option value="dd.MM.yy" name="field_format" type="QString"/>
-            <Option value="false" name="field_iso_format" type="bool"/>
+            <Option name="allow_null" type="bool" value="true"/>
+            <Option name="calendar_popup" type="bool" value="true"/>
+            <Option name="display_format" type="QString" value="dd.MM.yyyy"/>
+            <Option name="field_format" type="QString" value="dd.MM.yy"/>
+            <Option name="field_iso_format" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="textbody">
+    <field name="textbody" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="remark">
+    <field name="remark" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="true" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="true"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="idsgs">
+    <field name="idsgs" configurationFlags="None">
       <editWidget type="Range">
         <config>
           <Option type="Map">
-            <Option value="true" name="AllowNull" type="bool"/>
-            <Option value="1e+09" name="Max" type="double"/>
-            <Option value="0" name="Min" type="double"/>
-            <Option value="0" name="Precision" type="int"/>
-            <Option value="1" name="Step" type="double"/>
-            <Option value="SpinBox" name="Style" type="QString"/>
+            <Option name="AllowNull" type="bool" value="true"/>
+            <Option name="Max" type="double" value="1e+09"/>
+            <Option name="Min" type="double" value="0"/>
+            <Option name="Precision" type="int" value="0"/>
+            <Option name="Step" type="double" value="1"/>
+            <Option name="Style" type="QString" value="SpinBox"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="infogeoldata">
+    <field name="infogeoldata" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="infogeolcontactdata">
+    <field name="infogeolcontactdata" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="infogeolauxdata">
+    <field name="infogeolauxdata" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="titlepublic">
+    <field name="titlepublic" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="titleoriginal">
+    <field name="titleoriginal" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="akind">
+    <field name="akind" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" name="AllowAddFeatures" type="bool"/>
-            <Option value="true" name="AllowNULL" type="bool"/>
-            <Option value="false" name="ChainFilters" type="bool"/>
-            <Option value="" name="FilterExpression" type="QString"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="ChainFilters" type="bool" value="false"/>
+            <Option name="FilterExpression" type="QString" value=""/>
             <Option name="FilterFields" type="invalid"/>
-            <Option value="false" name="MapIdentification" type="bool"/>
-            <Option value="true" name="OrderByValue" type="bool"/>
-            <Option value="false" name="ReadOnly" type="bool"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetkinditem" name="ReferencedLayerDataSource" type="QString"/>
-            <Option value="AssetKindItem_61af4280_529e_4b86_90c5_68df5254d29f" name="ReferencedLayerId" type="QString"/>
-            <Option value="AssetKindItem" name="ReferencedLayerName" type="QString"/>
-            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
-            <Option value="lg_geolssts_v2geolassets_assetitem_akind_assetkinditem_T_Id" name="Relation" type="QString"/>
-            <Option value="false" name="ShowForm" type="bool"/>
-            <Option value="false" name="ShowOpenFormButton" type="bool"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetkinditem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetKindItem_61af4280_529e_4b86_90c5_68df5254d29f"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetKindItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="lg_geolssts_v2geolassets_assetitem_akind_assetkinditem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="datecreation">
+    <field name="datecreation" configurationFlags="None">
       <editWidget type="DateTime">
         <config>
           <Option type="Map">
-            <Option value="true" name="allow_null" type="bool"/>
-            <Option value="true" name="calendar_popup" type="bool"/>
-            <Option value="dd.MM.yyyy" name="display_format" type="QString"/>
-            <Option value="dd.MM.yy" name="field_format" type="QString"/>
-            <Option value="false" name="field_iso_format" type="bool"/>
+            <Option name="allow_null" type="bool" value="true"/>
+            <Option name="calendar_popup" type="bool" value="true"/>
+            <Option name="display_format" type="QString" value="dd.MM.yyyy"/>
+            <Option name="field_format" type="QString" value="dd.MM.yy"/>
+            <Option name="field_iso_format" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="alanguage">
+    <field name="alanguage" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" name="AllowAddFeatures" type="bool"/>
-            <Option value="true" name="AllowNULL" type="bool"/>
-            <Option value="false" name="ChainFilters" type="bool"/>
-            <Option value="" name="FilterExpression" type="QString"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="ChainFilters" type="bool" value="false"/>
+            <Option name="FilterExpression" type="QString" value=""/>
             <Option name="FilterFields" type="invalid"/>
-            <Option value="false" name="MapIdentification" type="bool"/>
-            <Option value="true" name="OrderByValue" type="bool"/>
-            <Option value="false" name="ReadOnly" type="bool"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=languageitem" name="ReferencedLayerDataSource" type="QString"/>
-            <Option value="LanguageItem_cd8d7272_96fc_46df_885d_993bcb12310c" name="ReferencedLayerId" type="QString"/>
-            <Option value="LanguageItem" name="ReferencedLayerName" type="QString"/>
-            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
-            <Option value="lg_geolssts_v2geolassets_assetitem_alanguage_languageitem_T_Id" name="Relation" type="QString"/>
-            <Option value="false" name="ShowForm" type="bool"/>
-            <Option value="false" name="ShowOpenFormButton" type="bool"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/data.gpkg|layername=languageitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="LanguageItem_2c89de9b_25e4_464d_9b59_8adff29fafaa"/>
+            <Option name="ReferencedLayerName" type="QString" value="LanguageItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="lg_geolssts_v2geolassets_assetitem_alanguage_languageitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="aformat">
+    <field name="aformat" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" name="AllowAddFeatures" type="bool"/>
-            <Option value="true" name="AllowNULL" type="bool"/>
-            <Option value="false" name="MapIdentification" type="bool"/>
-            <Option value="true" name="OrderByValue" type="bool"/>
-            <Option value="false" name="ReadOnly" type="bool"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=assetformatitem" name="ReferencedLayerDataSource" type="QString"/>
-            <Option value="AssetFormatItem_e25c2079_d9e2_40ec_98c5_efed3e20bfed" name="ReferencedLayerId" type="QString"/>
-            <Option value="AssetFormatItem" name="ReferencedLayerName" type="QString"/>
-            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
-            <Option value="lg_geolssts_v2geolassets_assetitem_aformat_assetformatitem_T_Id" name="Relation" type="QString"/>
-            <Option value="false" name="ShowForm" type="bool"/>
-            <Option value="false" name="ShowOpenFormButton" type="bool"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/data.gpkg|layername=assetformatitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetFormatItem_566fc974_a00e_4eb7_98c5_d65d755ea992"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetFormatItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="lg_geolssts_v2geolassets_assetitem_aformat_assetformatitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="authorbiblio">
+    <field name="authorbiblio" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="sourceproject">
+    <field name="sourceproject" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription">
+    <field name="adescription" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="isextract">
+    <field name="isextract" configurationFlags="None">
       <editWidget type="CheckBox">
         <config>
           <Option type="Map">
-            <Option value="" name="CheckedState" type="QString"/>
-            <Option value="0" name="TextDisplayMethod" type="int"/>
-            <Option value="" name="UncheckedState" type="QString"/>
+            <Option name="CheckedState" type="QString" value=""/>
+            <Option name="TextDisplayMethod" type="int" value="0"/>
+            <Option name="UncheckedState" type="QString" value=""/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="assetitemmain_assetitem">
+    <field name="assetitemmain_assetitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" name="AllowAddFeatures" type="bool"/>
-            <Option value="false" name="AllowNULL" type="bool"/>
-            <Option value="false" name="MapIdentification" type="bool"/>
-            <Option value="false" name="OrderByValue" type="bool"/>
-            <Option value="false" name="ReadOnly" type="bool"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem" name="ReferencedLayerDataSource" type="QString"/>
-            <Option value="AssetItem_d7d09df7_c258_42f5_8263_23014de57c8d" name="ReferencedLayerId" type="QString"/>
-            <Option value="AssetItem" name="ReferencedLayerName" type="QString"/>
-            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
-            <Option value="lg_geolssts_v2geolassets_assetitem_assetitemmain_assetitem_assetitem_T_Id" name="Relation" type="QString"/>
-            <Option value="false" name="ShowForm" type="bool"/>
-            <Option value="true" name="ShowOpenFormButton" type="bool"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetItem_d7d09df7_c258_42f5_8263_23014de57c8d"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="lg_geolssts_v2geolassets_assetitem_assetitemmain_assetitem_assetitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="assetitemmain_lg_geolssts_v2geolassets_assetitem">
+    <field name="assetitemmain_lg_geolssts_v2geolassets_assetitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="true" name="AllowAddFeatures" type="bool"/>
-            <Option value="true" name="AllowNULL" type="bool"/>
-            <Option value="false" name="MapIdentification" type="bool"/>
-            <Option value="false" name="OrderByValue" type="bool"/>
-            <Option value="false" name="ReadOnly" type="bool"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" name="ReferencedLayerDataSource" type="QString"/>
-            <Option value="AssetItem_655d7d08_f608_4aef_b23f_9bfc2ff514b1" name="ReferencedLayerId" type="QString"/>
-            <Option value="AssetItem" name="ReferencedLayerName" type="QString"/>
-            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
-            <Option value="lg_geolssts_v2geolassets_assetitem_assetitemmain_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" name="Relation" type="QString"/>
-            <Option value="false" name="ShowForm" type="bool"/>
-            <Option value="true" name="ShowOpenFormButton" type="bool"/>
+            <Option name="AllowAddFeatures" type="bool" value="true"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetItem_61ad9e96_9cd2_4213_bedb_4a8d01b23346"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="lg_geolssts_v2geolassets_assetitem_assetitemmain_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="Teilasset Info" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="true"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias index="0" name="" field="T_Id"/>
-    <alias index="1" name="" field="T_basket"/>
-    <alias index="2" name="" field="T_Ili_Tid"/>
-    <alias index="3" name="Ist relevant" field="isnatrel"/>
-    <alias index="4" name="Eingangsdatum" field="datereceipt"/>
-    <alias index="5" name="Gemeinde" field="municipality"/>
-    <alias index="6" name="URL zu einer Online-Ressource" field="url"/>
-    <alias index="7" name="File" field="relativepath"/>
-    <alias index="8" name="Physischer Standort des analogen Dokuments" field="locationanalog"/>
-    <alias index="9" name="Bearbeiter" field="processor"/>
-    <alias index="10" name="Letztes Bearbeitungsdatum" field="datelastprocessed"/>
-    <alias index="11" name="Textkörper" field="textbody"/>
-    <alias index="12" name="Sonstige Bemerkungen" field="remark"/>
-    <alias index="13" name="IDSGS" field="idsgs"/>
-    <alias index="14" name="Daten" field="infogeoldata"/>
-    <alias index="15" name="Kontaktinformationen" field="infogeolcontactdata"/>
-    <alias index="16" name="Auxiliary Information" field="infogeolauxdata"/>
-    <alias index="17" name="Öffentlicher Titel" field="titlepublic"/>
-    <alias index="18" name="Original Titel" field="titleoriginal"/>
-    <alias index="19" name="Art" field="akind"/>
-    <alias index="20" name="Asset-Erstellungsdatum" field="datecreation"/>
-    <alias index="21" name="Sprache" field="alanguage"/>
-    <alias index="22" name="Format" field="aformat"/>
-    <alias index="23" name="Autoren" field="authorbiblio"/>
-    <alias index="24" name="Projekt im Rahmen dessen das Asset erstellt wurde" field="sourceproject"/>
-    <alias index="25" name="Beschreibung" field="adescription"/>
-    <alias index="26" name="IsExtract" field="isextract"/>
-    <alias index="27" name="AssetItemMain" field="assetitemmain_assetitem"/>
-    <alias index="28" name="AssetItemMain" field="assetitemmain_lg_geolssts_v2geolassets_assetitem"/>
+    <alias name="" field="T_Id" index="0"/>
+    <alias name="" field="T_basket" index="1"/>
+    <alias name="" field="T_Ili_Tid" index="2"/>
+    <alias name="Ist relevant" field="isnatrel" index="3"/>
+    <alias name="Eingangsdatum" field="datereceipt" index="4"/>
+    <alias name="Gemeinde" field="municipality" index="5"/>
+    <alias name="URL zu einer Online-Ressource" field="url" index="6"/>
+    <alias name="File" field="relativepath" index="7"/>
+    <alias name="Physischer Standort des analogen Dokuments" field="locationanalog" index="8"/>
+    <alias name="Bearbeiter" field="processor" index="9"/>
+    <alias name="Letztes Bearbeitungsdatum" field="datelastprocessed" index="10"/>
+    <alias name="Textkörper" field="textbody" index="11"/>
+    <alias name="Sonstige Bemerkungen" field="remark" index="12"/>
+    <alias name="IDSGS" field="idsgs" index="13"/>
+    <alias name="Daten" field="infogeoldata" index="14"/>
+    <alias name="Kontaktinformationen" field="infogeolcontactdata" index="15"/>
+    <alias name="Auxiliary Information" field="infogeolauxdata" index="16"/>
+    <alias name="Öffentlicher Titel" field="titlepublic" index="17"/>
+    <alias name="Original Titel" field="titleoriginal" index="18"/>
+    <alias name="Art" field="akind" index="19"/>
+    <alias name="Asset-Erstellungsdatum" field="datecreation" index="20"/>
+    <alias name="Sprache" field="alanguage" index="21"/>
+    <alias name="Format" field="aformat" index="22"/>
+    <alias name="Autoren" field="authorbiblio" index="23"/>
+    <alias name="Projekt im Rahmen dessen das Asset erstellt wurde" field="sourceproject" index="24"/>
+    <alias name="Beschreibung" field="adescription" index="25"/>
+    <alias name="Dieser Asset ist ein Teilasset" field="isextract" index="26"/>
+    <alias name="AssetItemMain" field="assetitemmain_assetitem" index="27"/>
+    <alias name="Hauptasset (von dem dieses AssetItem ein Teil ist)" field="assetitemmain_lg_geolssts_v2geolassets_assetitem" index="28"/>
+    <alias name="" field="Teilasset Info" index="29"/>
   </aliases>
   <defaults>
-    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
-    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
-    <default applyOnUpdate="0" field="T_Ili_Tid" expression="substr(uuid(), 2, 36)"/>
-    <default applyOnUpdate="0" field="isnatrel" expression=""/>
-    <default applyOnUpdate="0" field="datereceipt" expression=""/>
-    <default applyOnUpdate="0" field="municipality" expression=""/>
-    <default applyOnUpdate="0" field="url" expression=""/>
-    <default applyOnUpdate="0" field="relativepath" expression=""/>
-    <default applyOnUpdate="0" field="locationanalog" expression=""/>
-    <default applyOnUpdate="0" field="processor" expression=""/>
-    <default applyOnUpdate="0" field="datelastprocessed" expression="now()"/>
-    <default applyOnUpdate="0" field="textbody" expression=""/>
-    <default applyOnUpdate="0" field="remark" expression=""/>
-    <default applyOnUpdate="0" field="idsgs" expression=""/>
-    <default applyOnUpdate="0" field="infogeoldata" expression=""/>
-    <default applyOnUpdate="0" field="infogeolcontactdata" expression=""/>
-    <default applyOnUpdate="0" field="infogeolauxdata" expression=""/>
-    <default applyOnUpdate="0" field="titlepublic" expression=""/>
-    <default applyOnUpdate="0" field="titleoriginal" expression=""/>
-    <default applyOnUpdate="0" field="akind" expression=""/>
-    <default applyOnUpdate="0" field="datecreation" expression=""/>
-    <default applyOnUpdate="0" field="alanguage" expression=""/>
-    <default applyOnUpdate="0" field="aformat" expression="attribute(get_feature('AssetFormatItem', 'Code', 'pdf'), 'T_Id')"/>
-    <default applyOnUpdate="0" field="authorbiblio" expression=""/>
-    <default applyOnUpdate="0" field="sourceproject" expression=""/>
-    <default applyOnUpdate="0" field="adescription" expression=""/>
-    <default applyOnUpdate="0" field="isextract" expression="false"/>
-    <default applyOnUpdate="0" field="assetitemmain_assetitem" expression=""/>
-    <default applyOnUpdate="0" field="assetitemmain_lg_geolssts_v2geolassets_assetitem" expression=""/>
+    <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
+    <default field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets" applyOnUpdate="0"/>
+    <default field="T_Ili_Tid" expression="substr(uuid(), 2, 36)" applyOnUpdate="0"/>
+    <default field="isnatrel" expression="" applyOnUpdate="0"/>
+    <default field="datereceipt" expression="" applyOnUpdate="0"/>
+    <default field="municipality" expression="" applyOnUpdate="0"/>
+    <default field="url" expression="" applyOnUpdate="0"/>
+    <default field="relativepath" expression="" applyOnUpdate="0"/>
+    <default field="locationanalog" expression="" applyOnUpdate="0"/>
+    <default field="processor" expression="" applyOnUpdate="0"/>
+    <default field="datelastprocessed" expression="now()" applyOnUpdate="0"/>
+    <default field="textbody" expression="" applyOnUpdate="0"/>
+    <default field="remark" expression="" applyOnUpdate="0"/>
+    <default field="idsgs" expression="" applyOnUpdate="0"/>
+    <default field="infogeoldata" expression="" applyOnUpdate="0"/>
+    <default field="infogeolcontactdata" expression="" applyOnUpdate="0"/>
+    <default field="infogeolauxdata" expression="" applyOnUpdate="0"/>
+    <default field="titlepublic" expression="" applyOnUpdate="0"/>
+    <default field="titleoriginal" expression="" applyOnUpdate="0"/>
+    <default field="akind" expression="" applyOnUpdate="0"/>
+    <default field="datecreation" expression="" applyOnUpdate="0"/>
+    <default field="alanguage" expression="" applyOnUpdate="0"/>
+    <default field="aformat" expression="attribute(get_feature('AssetFormatItem', 'Code', 'pdf'), 'T_Id')" applyOnUpdate="0"/>
+    <default field="authorbiblio" expression="" applyOnUpdate="0"/>
+    <default field="sourceproject" expression="" applyOnUpdate="0"/>
+    <default field="adescription" expression="" applyOnUpdate="0"/>
+    <default field="isextract" expression="false" applyOnUpdate="0"/>
+    <default field="assetitemmain_assetitem" expression="" applyOnUpdate="0"/>
+    <default field="assetitemmain_lg_geolssts_v2geolassets_assetitem" expression="" applyOnUpdate="0"/>
+    <default field="Teilasset Info" expression="'Dieser Reiter wird nur angezeigt, wenn das AssetItem selbst kein Teilasset ist.'" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" constraints="3" exp_strength="0" field="T_Id" notnull_strength="1"/>
-    <constraint unique_strength="0" constraints="1" exp_strength="0" field="T_basket" notnull_strength="1"/>
-    <constraint unique_strength="0" constraints="0" exp_strength="0" field="T_Ili_Tid" notnull_strength="0"/>
-    <constraint unique_strength="0" constraints="1" exp_strength="0" field="isnatrel" notnull_strength="1"/>
-    <constraint unique_strength="0" constraints="1" exp_strength="0" field="datereceipt" notnull_strength="1"/>
-    <constraint unique_strength="0" constraints="0" exp_strength="0" field="municipality" notnull_strength="0"/>
-    <constraint unique_strength="0" constraints="0" exp_strength="0" field="url" notnull_strength="0"/>
-    <constraint unique_strength="0" constraints="1" exp_strength="0" field="relativepath" notnull_strength="1"/>
-    <constraint unique_strength="0" constraints="0" exp_strength="0" field="locationanalog" notnull_strength="0"/>
-    <constraint unique_strength="0" constraints="0" exp_strength="0" field="processor" notnull_strength="0"/>
-    <constraint unique_strength="0" constraints="1" exp_strength="0" field="datelastprocessed" notnull_strength="1"/>
-    <constraint unique_strength="0" constraints="0" exp_strength="0" field="textbody" notnull_strength="0"/>
-    <constraint unique_strength="0" constraints="0" exp_strength="0" field="remark" notnull_strength="0"/>
-    <constraint unique_strength="0" constraints="0" exp_strength="0" field="idsgs" notnull_strength="0"/>
-    <constraint unique_strength="0" constraints="0" exp_strength="0" field="infogeoldata" notnull_strength="0"/>
-    <constraint unique_strength="0" constraints="0" exp_strength="0" field="infogeolcontactdata" notnull_strength="0"/>
-    <constraint unique_strength="0" constraints="0" exp_strength="0" field="infogeolauxdata" notnull_strength="0"/>
-    <constraint unique_strength="0" constraints="0" exp_strength="0" field="titlepublic" notnull_strength="0"/>
-    <constraint unique_strength="0" constraints="1" exp_strength="0" field="titleoriginal" notnull_strength="1"/>
-    <constraint unique_strength="0" constraints="1" exp_strength="0" field="akind" notnull_strength="1"/>
-    <constraint unique_strength="0" constraints="1" exp_strength="0" field="datecreation" notnull_strength="1"/>
-    <constraint unique_strength="0" constraints="1" exp_strength="0" field="alanguage" notnull_strength="1"/>
-    <constraint unique_strength="0" constraints="1" exp_strength="0" field="aformat" notnull_strength="1"/>
-    <constraint unique_strength="0" constraints="0" exp_strength="0" field="authorbiblio" notnull_strength="0"/>
-    <constraint unique_strength="0" constraints="0" exp_strength="0" field="sourceproject" notnull_strength="0"/>
-    <constraint unique_strength="0" constraints="0" exp_strength="0" field="adescription" notnull_strength="0"/>
-    <constraint unique_strength="0" constraints="1" exp_strength="0" field="isextract" notnull_strength="1"/>
-    <constraint unique_strength="0" constraints="0" exp_strength="0" field="assetitemmain_assetitem" notnull_strength="0"/>
-    <constraint unique_strength="0" constraints="0" exp_strength="0" field="assetitemmain_lg_geolssts_v2geolassets_assetitem" notnull_strength="0"/>
+    <constraint constraints="3" field="T_Id" unique_strength="1" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="1" field="T_basket" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="T_Ili_Tid" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="1" field="isnatrel" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="1" field="datereceipt" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="municipality" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="url" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="1" field="relativepath" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="locationanalog" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="processor" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="1" field="datelastprocessed" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="textbody" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="remark" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="idsgs" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="infogeoldata" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="infogeolcontactdata" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="infogeolauxdata" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="titlepublic" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="1" field="titleoriginal" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="1" field="akind" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="1" field="datecreation" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="1" field="alanguage" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="1" field="aformat" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="authorbiblio" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="sourceproject" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="1" field="isextract" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="assetitemmain_assetitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="assetitemmain_lg_geolssts_v2geolassets_assetitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="Teilasset Info" unique_strength="0" exp_strength="0" notnull_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" desc="" field="T_Id"/>
-    <constraint exp="" desc="" field="T_basket"/>
-    <constraint exp="" desc="" field="T_Ili_Tid"/>
-    <constraint exp="" desc="" field="isnatrel"/>
-    <constraint exp="" desc="" field="datereceipt"/>
-    <constraint exp="" desc="" field="municipality"/>
-    <constraint exp="" desc="" field="url"/>
-    <constraint exp="" desc="" field="relativepath"/>
-    <constraint exp="" desc="" field="locationanalog"/>
-    <constraint exp="" desc="" field="processor"/>
-    <constraint exp="" desc="" field="datelastprocessed"/>
-    <constraint exp="" desc="" field="textbody"/>
-    <constraint exp="" desc="" field="remark"/>
-    <constraint exp="" desc="" field="idsgs"/>
-    <constraint exp="" desc="" field="infogeoldata"/>
-    <constraint exp="" desc="" field="infogeolcontactdata"/>
-    <constraint exp="" desc="" field="infogeolauxdata"/>
-    <constraint exp="" desc="" field="titlepublic"/>
-    <constraint exp="" desc="" field="titleoriginal"/>
-    <constraint exp="" desc="" field="akind"/>
-    <constraint exp="" desc="" field="datecreation"/>
-    <constraint exp="" desc="" field="alanguage"/>
-    <constraint exp="" desc="" field="aformat"/>
-    <constraint exp="" desc="" field="authorbiblio"/>
-    <constraint exp="" desc="" field="sourceproject"/>
-    <constraint exp="" desc="" field="adescription"/>
-    <constraint exp="" desc="" field="isextract"/>
-    <constraint exp="" desc="" field="assetitemmain_assetitem"/>
-    <constraint exp="" desc="" field="assetitemmain_lg_geolssts_v2geolassets_assetitem"/>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="T_Ili_Tid" desc=""/>
+    <constraint exp="" field="isnatrel" desc=""/>
+    <constraint exp="" field="datereceipt" desc=""/>
+    <constraint exp="" field="municipality" desc=""/>
+    <constraint exp="" field="url" desc=""/>
+    <constraint exp="" field="relativepath" desc=""/>
+    <constraint exp="" field="locationanalog" desc=""/>
+    <constraint exp="" field="processor" desc=""/>
+    <constraint exp="" field="datelastprocessed" desc=""/>
+    <constraint exp="" field="textbody" desc=""/>
+    <constraint exp="" field="remark" desc=""/>
+    <constraint exp="" field="idsgs" desc=""/>
+    <constraint exp="" field="infogeoldata" desc=""/>
+    <constraint exp="" field="infogeolcontactdata" desc=""/>
+    <constraint exp="" field="infogeolauxdata" desc=""/>
+    <constraint exp="" field="titlepublic" desc=""/>
+    <constraint exp="" field="titleoriginal" desc=""/>
+    <constraint exp="" field="akind" desc=""/>
+    <constraint exp="" field="datecreation" desc=""/>
+    <constraint exp="" field="alanguage" desc=""/>
+    <constraint exp="" field="aformat" desc=""/>
+    <constraint exp="" field="authorbiblio" desc=""/>
+    <constraint exp="" field="sourceproject" desc=""/>
+    <constraint exp="" field="adescription" desc=""/>
+    <constraint exp="" field="isextract" desc=""/>
+    <constraint exp="" field="assetitemmain_assetitem" desc=""/>
+    <constraint exp="" field="assetitemmain_lg_geolssts_v2geolassets_assetitem" desc=""/>
+    <constraint exp="" field="Teilasset Info" desc=""/>
   </constraintExpressions>
-  <expressionfields/>
+  <expressionfields>
+    <field typeName="string" name="Teilasset Info" subType="0" expression="'Dieser Reiter wird nur angezeigt, wenn das AssetItem selbst kein Teilasset ist.&#xa;&#xa;Hier besteht ein Bug, dass QGIS in der Attributtabelle den Fokus auf den aktuellen Asset verliert. Falls du diesen Reiter in der Attributtabelle direkt (nicht über &quot;Öffne Formular einzeln&quot; angewählt hast), schliesse die Attributtabelle und öffne sie erneut.'" type="10" length="0" precision="0" comment=""/>
+  </expressionfields>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <actionsetting shortTitle="Open Single Form" action="project = QgsProject.instance()&#xa;layer = QgsProject.instance().mapLayer('[% @layer_id %]')&#xa;feature =  layer.getFeature( [% $id %] )&#xa;form = qgis.utils.iface.getFeatureForm(layer, feature)&#xa;form.show()" id="{2c81fad2-2b72-42e5-b823-ddfbcec13d8b}" name="Öffne Formular einzeln" icon="" type="1" notificationMessage="" isEnabledOnlyWhenEditable="0" capture="0">
+      <actionScope id="Feature"/>
+    </actionsetting>
+  </attributeactions>
   <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
@@ -537,31 +559,31 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer columnCount="2" name="Info" visibilityExpression="" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
-      <attributeEditorContainer columnCount="1" name="Titel" visibilityExpression="" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Info *" columnCount="2" groupBox="0" showLabel="1">
+      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Titel" columnCount="1" groupBox="1" showLabel="1">
         <attributeEditorField name="titleoriginal" index="18" showLabel="1"/>
         <attributeEditorField name="titlepublic" index="17" showLabel="1"/>
         <attributeEditorField name="sourceproject" index="24" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer columnCount="1" name="Identifikatoren" visibilityExpression="" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Identifikatoren" columnCount="1" groupBox="1" showLabel="1">
         <attributeEditorField name="idsgs" index="13" showLabel="1"/>
-        <attributeEditorRelation relation="id_lg_glssts_vssts_ssttem_idalternate_lg_geolssts_v2geolassets_assetitem_T_Id" label="IDs" relationWidgetTypeId="relation_editor" nmRelationId="" name="id_lg_glssts_vssts_ssttem_idalternate_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="1" forceSuppressFormPopup="0">
+        <attributeEditorRelation forceSuppressFormPopup="0" name="id_lg_glssts_vssts_ssttem_idalternate_lg_geolssts_v2geolassets_assetitem_T_Id" label="IDs" relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="1" relation="id_lg_glssts_vssts_ssttem_idalternate_lg_geolssts_v2geolassets_assetitem_T_Id">
           <editor_configuration type="Map">
-            <Option value="AddChildFeature|DeleteChildFeature" name="buttons" type="QString"/>
-            <Option value="true" name="show_first_feature" type="bool"/>
+            <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature"/>
+            <Option name="show_first_feature" type="bool" value="true"/>
           </editor_configuration>
         </attributeEditorRelation>
       </attributeEditorContainer>
     </attributeEditorContainer>
-    <attributeEditorContainer columnCount="2" name="Allgemein" visibilityExpression="" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
-      <attributeEditorContainer columnCount="1" name="Beschreibung" visibilityExpression="" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Allgemein *" columnCount="2" groupBox="0" showLabel="1">
+      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Beschreibung" columnCount="1" groupBox="1" showLabel="1">
         <attributeEditorField name="datecreation" index="20" showLabel="1"/>
         <attributeEditorField name="alanguage" index="21" showLabel="1"/>
-        <attributeEditorContainer columnCount="1" name="Manuell vergebe Label (mindestens ein Eintrag)" visibilityExpression="" showLabel="1" backgroundColor="#ffe0b2" groupBox="1" visibilityExpressionEnabled="0">
-          <attributeEditorRelation relation="mancatlabelref_lg_glssts_vssts_ssttem_mancatlabel_lg_geolssts_v2geolassets_assetitem_T_Id" label="Manuell vergebe Label (mindestens ein Eintrag)" relationWidgetTypeId="relation_editor" nmRelationId="mancatlabelref_areference_mancatlabelitem_T_Id" name="mancatlabelref_lg_glssts_vssts_ssttem_mancatlabel_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="0" forceSuppressFormPopup="0">
+        <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" backgroundColor="#ffe0b2" name="Manuell vergebe Label (mindestens ein Eintrag)" columnCount="1" groupBox="1" showLabel="1">
+          <attributeEditorRelation forceSuppressFormPopup="0" name="mancatlabelref_lg_glssts_vssts_ssttem_mancatlabel_lg_geolssts_v2geolassets_assetitem_T_Id" label="Manuell vergebe Label (mindestens ein Eintrag)" relationWidgetTypeId="relation_editor" nmRelationId="mancatlabelref_areference_mancatlabelitem_T_Id" showLabel="0" relation="mancatlabelref_lg_glssts_vssts_ssttem_mancatlabel_lg_geolssts_v2geolassets_assetitem_T_Id">
             <editor_configuration type="Map">
-              <Option value="Link|Unlink" name="buttons" type="QString"/>
-              <Option value="true" name="show_first_feature" type="bool"/>
+              <Option name="buttons" type="QString" value="Link|Unlink"/>
+              <Option name="show_first_feature" type="bool" value="true"/>
             </editor_configuration>
           </attributeEditorRelation>
         </attributeEditorContainer>
@@ -569,28 +591,29 @@ def my_form_open(dialog, layer, feature):
         <attributeEditorField name="authorbiblio" index="23" showLabel="1"/>
         <attributeEditorField name="remark" index="12" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer columnCount="1" name="" visibilityExpression="" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
-        <attributeEditorContainer columnCount="1" name="Eigenschaften" visibilityExpression="" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Eigenschaften" columnCount="1" groupBox="1" showLabel="1">
+        <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Format" columnCount="1" groupBox="1" showLabel="1">
           <attributeEditorField name="akind" index="19" showLabel="1"/>
           <attributeEditorField name="aformat" index="22" showLabel="1"/>
-          <attributeEditorContainer columnCount="1" name="Formate der Parts" visibilityExpression="attribute(get_feature('AssetKindItem', 't_id', akind),'code') is 'package'" showLabel="1" groupBox="1" visibilityExpressionEnabled="1">
-            <attributeEditorRelation relation="assetformatref_lg_glssts_vssts_ssttem_formatcomposition_lg_geolssts_v2geolassets_assetitem_T_Id" label="Formate der Parts" relationWidgetTypeId="relation_editor" nmRelationId="assetformatref_areference_assetformatitem_T_Id" name="assetformatref_lg_glssts_vssts_ssttem_formatcomposition_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="0" forceSuppressFormPopup="0">
+          <attributeEditorContainer visibilityExpressionEnabled="1" visibilityExpression="attribute(get_feature('AssetKindItem', 't_id', akind),'code') is 'package'" name="Formate der Teile" columnCount="1" groupBox="1" showLabel="1">
+            <attributeEditorRelation forceSuppressFormPopup="0" name="assetformatref_lg_glssts_vssts_ssttem_formatcomposition_lg_geolssts_v2geolassets_assetitem_T_Id" label="Formate der Parts" relationWidgetTypeId="relation_editor" nmRelationId="assetformatref_areference_assetformatitem_T_Id" showLabel="0" relation="assetformatref_lg_glssts_vssts_ssttem_formatcomposition_lg_geolssts_v2geolassets_assetitem_T_Id">
               <editor_configuration type="Map">
-                <Option value="AllButtons" name="buttons" type="QString"/>
-                <Option value="true" name="show_first_feature" type="bool"/>
+                <Option name="buttons" type="QString" value="AllButtons"/>
+                <Option name="show_first_feature" type="bool" value="true"/>
               </editor_configuration>
             </attributeEditorRelation>
           </attributeEditorContainer>
         </attributeEditorContainer>
-        <attributeEditorContainer columnCount="1" name="Extract" visibilityExpression="" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+        <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Teilasset" columnCount="1" groupBox="1" showLabel="1">
           <attributeEditorField name="isextract" index="26" showLabel="1"/>
-          <attributeEditorContainer columnCount="1" name="AssetPart Attribute" visibilityExpression="&quot;isextract&quot;" showLabel="1" groupBox="1" visibilityExpressionEnabled="1">
+          <attributeEditorContainer visibilityExpressionEnabled="1" visibilityExpression="&quot;isextract&quot;" name="Eigenschaften" columnCount="1" groupBox="1" showLabel="1">
             <attributeEditorField name="assetitemmain_lg_geolssts_v2geolassets_assetitem" index="28" showLabel="1"/>
-            <attributeEditorContainer columnCount="1" name="Asset Part Info (nur ein Eintrag)" visibilityExpression="" showLabel="1" backgroundColor="#ffe0b2" groupBox="1" visibilityExpressionEnabled="0">
-              <attributeEditorRelation relation="assetobjectinfo_lg_glssts_vssts_ssttem_assetobjectinfo_lg_geolssts_v2geolassets_assetitem_T_Id" label="Asset Part Info (nur ein Eintrag)" relationWidgetTypeId="relation_editor" nmRelationId="" name="assetobjectinfo_lg_glssts_vssts_ssttem_assetobjectinfo_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="0" forceSuppressFormPopup="0">
+            <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" backgroundColor="#ffe0b2" name="Teilasset Info" columnCount="1" groupBox="1" showLabel="1">
+              <attributeEditorRelation forceSuppressFormPopup="0" name="assetobjectinfo_lg_glssts_vssts_ssttem_assetobjectinfo_lg_geolssts_v2geolassets_assetitem_T_Id" label="Asset Part Info (nur ein Eintrag)" relationWidgetTypeId="linking_relation_editor" nmRelationId="one_to_one" showLabel="0" relation="assetobjectinfo_lg_glssts_vssts_ssttem_assetobjectinfo_lg_geolssts_v2geolassets_assetitem_T_Id">
                 <editor_configuration type="Map">
-                  <Option value="AddChildFeature|DeleteChildFeature" name="buttons" type="QString"/>
-                  <Option value="true" name="show_first_feature" type="bool"/>
+                  <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature"/>
+                  <Option name="one_to_one" type="bool" value="true"/>
+                  <Option name="show_first_feature" type="bool" value="true"/>
                 </editor_configuration>
               </attributeEditorRelation>
             </attributeEditorContainer>
@@ -598,235 +621,242 @@ def my_form_open(dialog, layer, feature):
         </attributeEditorContainer>
       </attributeEditorContainer>
     </attributeEditorContainer>
-    <attributeEditorContainer columnCount="1" name="AssetMain Attribute" visibilityExpression="NOT isextract" showLabel="1" groupBox="0" visibilityExpressionEnabled="1">
-      <attributeEditorRelation relation="lg_geolssts_v2geolassets_assetitem_assetitemmain_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="AssetParts" relationWidgetTypeId="relation_editor" nmRelationId="" name="lg_geolssts_v2geolassets_assetitem_assetitemmain_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="1" forceSuppressFormPopup="0">
-        <editor_configuration type="Map">
-          <Option value="Link|Unlink|AddChildFeature|DeleteChildFeature" name="buttons" type="QString"/>
-          <Option value="true" name="show_first_feature" type="bool"/>
-        </editor_configuration>
-      </attributeEditorRelation>
-      <attributeEditorRelation relation="assetkindref_lg_glssts_vssts_ssttem_assetcomposition_lg_geolssts_v2geolassets_assetitem_T_Id" label="Arten der Parts" relationWidgetTypeId="relation_editor" nmRelationId="assetkindref_areference_assetkinditem_T_Id" name="assetkindref_lg_glssts_vssts_ssttem_assetcomposition_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="1" forceSuppressFormPopup="0">
-        <editor_configuration type="Map">
-          <Option value="Link|Unlink" name="buttons" type="QString"/>
-          <Option value="true" name="show_first_feature" type="bool"/>
-        </editor_configuration>
-      </attributeEditorRelation>
-    </attributeEditorContainer>
-    <attributeEditorContainer columnCount="2" name="Nutzung" visibilityExpression="" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
-      <attributeEditorContainer columnCount="1" name="Nutzung" visibilityExpression="" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
-        <attributeEditorContainer columnCount="1" name="Interne Nutzung (genau ein Eintrag)" visibilityExpression="" showLabel="1" backgroundColor="#ffe0b2" groupBox="1" visibilityExpressionEnabled="0">
-          <attributeEditorRelation relation="internaluse_lg_glssts_vssts_ssttem_internaluse_lg_geolssts_v2geolassets_assetitem_T_Id" label="Interne Nutzung (genau ein Eintrag)" relationWidgetTypeId="relation_editor" nmRelationId="" name="internaluse_lg_glssts_vssts_ssttem_internaluse_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="0" forceSuppressFormPopup="0">
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Nutzung" columnCount="2" groupBox="0" showLabel="1">
+      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Nutzung" columnCount="1" groupBox="1" showLabel="1">
+        <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" backgroundColor="#ffe0b2" name="Interne Nutzung" columnCount="1" groupBox="1" showLabel="1">
+          <attributeEditorRelation forceSuppressFormPopup="0" name="internaluse_lg_glssts_vssts_ssttem_internaluse_lg_geolssts_v2geolassets_assetitem_T_Id" label="Interne Nutzung" relationWidgetTypeId="linking_relation_editor" nmRelationId="one_to_one" showLabel="0" relation="internaluse_lg_glssts_vssts_ssttem_internaluse_lg_geolssts_v2geolassets_assetitem_T_Id">
             <editor_configuration type="Map">
-              <Option value="AddChildFeature|DeleteChildFeature" name="buttons" type="QString"/>
-              <Option value="true" name="show_first_feature" type="bool"/>
+              <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature"/>
+              <Option name="one_to_one" type="bool" value="true"/>
+              <Option name="show_first_feature" type="bool" value="true"/>
             </editor_configuration>
           </attributeEditorRelation>
         </attributeEditorContainer>
-        <attributeEditorContainer columnCount="1" name="Öffentliche Nutzung (genau ein Eintrag)" visibilityExpression="" showLabel="1" backgroundColor="#ffe0b2" groupBox="1" visibilityExpressionEnabled="0">
-          <attributeEditorRelation relation="publicuse_lg_glssts_vssts_ssttem_publicuse_lg_geolssts_v2geolassets_assetitem_T_Id" label="Öffentliche Nutzung (genau ein Eintrag)" relationWidgetTypeId="relation_editor" nmRelationId="" name="publicuse_lg_glssts_vssts_ssttem_publicuse_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="1" forceSuppressFormPopup="0">
+        <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" backgroundColor="#ffe0b2" name="Öffentliche Nutzung" columnCount="1" groupBox="1" showLabel="1">
+          <attributeEditorRelation forceSuppressFormPopup="0" name="publicuse_lg_glssts_vssts_ssttem_publicuse_lg_geolssts_v2geolassets_assetitem_T_Id" label="Öffentliche Nutzung" relationWidgetTypeId="linking_relation_editor" nmRelationId="one_to_one" showLabel="0" relation="publicuse_lg_glssts_vssts_ssttem_publicuse_lg_geolssts_v2geolassets_assetitem_T_Id">
             <editor_configuration type="Map">
-              <Option value="AddChildFeature|DeleteChildFeature" name="buttons" type="QString"/>
-              <Option value="true" name="show_first_feature" type="bool"/>
+              <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature"/>
+              <Option name="one_to_one" type="bool" value="true"/>
+              <Option name="show_first_feature" type="bool" value="true"/>
             </editor_configuration>
           </attributeEditorRelation>
         </attributeEditorContainer>
       </attributeEditorContainer>
-      <attributeEditorContainer columnCount="1" name="Nationale Relevanz" visibilityExpression="" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Nationale Relevanz" columnCount="1" groupBox="1" showLabel="1">
         <attributeEditorField name="isnatrel" index="3" showLabel="1"/>
-        <attributeEditorContainer columnCount="1" name="Type(n)" visibilityExpression="&quot;isnatrel&quot;" showLabel="1" groupBox="1" visibilityExpressionEnabled="1">
-          <attributeEditorRelation relation="typenatrel_lg_glssts_vssts_ssttem_typenatrel_lg_geolssts_v2geolassets_assetitem_T_Id" label="" relationWidgetTypeId="relation_editor" nmRelationId="typenatrel_typenatrel_natrelitem_T_Id" name="typenatrel_lg_glssts_vssts_ssttem_typenatrel_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="0" forceSuppressFormPopup="0">
+        <attributeEditorContainer visibilityExpressionEnabled="1" visibilityExpression="&quot;isnatrel&quot;" name="Type(n)" columnCount="1" groupBox="1" showLabel="1">
+          <attributeEditorRelation forceSuppressFormPopup="0" name="typenatrel_lg_glssts_vssts_ssttem_typenatrel_lg_geolssts_v2geolassets_assetitem_T_Id" label="" relationWidgetTypeId="relation_editor" nmRelationId="typenatrel_typenatrel_natrelitem_T_Id" showLabel="0" relation="typenatrel_lg_glssts_vssts_ssttem_typenatrel_lg_geolssts_v2geolassets_assetitem_T_Id">
             <editor_configuration type="Map">
-              <Option value="Link|Unlink" name="buttons" type="QString"/>
-              <Option value="true" name="show_first_feature" type="bool"/>
+              <Option name="buttons" type="QString" value="Link|Unlink"/>
+              <Option name="show_first_feature" type="bool" value="true"/>
             </editor_configuration>
           </attributeEditorRelation>
         </attributeEditorContainer>
       </attributeEditorContainer>
     </attributeEditorContainer>
-    <attributeEditorContainer columnCount="1" name="Lage (Geometrien)" visibilityExpression="" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
-      <attributeEditorRelation relation="studylocation_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Study Location" relationWidgetTypeId="relation_editor" nmRelationId="" name="studylocation_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="1" forceSuppressFormPopup="0">
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Lage (Geometrien)" columnCount="1" groupBox="0" showLabel="1">
+      <attributeEditorRelation forceSuppressFormPopup="0" name="studylocation_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Study Location" relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="1" relation="studylocation_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
         <editor_configuration type="Map">
-          <Option value="AddChildFeature|DeleteChildFeature|ZoomToChildFeature" name="buttons" type="QString"/>
-          <Option value="true" name="show_first_feature" type="bool"/>
+          <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature|ZoomToChildFeature"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
-      <attributeEditorRelation relation="studytrace_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Study Trace" relationWidgetTypeId="relation_editor" nmRelationId="" name="studytrace_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="1" forceSuppressFormPopup="0">
+      <attributeEditorRelation forceSuppressFormPopup="0" name="studytrace_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Study Trace" relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="1" relation="studytrace_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
         <editor_configuration type="Map">
-          <Option value="AddChildFeature|DeleteChildFeature|ZoomToChildFeature" name="buttons" type="QString"/>
-          <Option value="true" name="show_first_feature" type="bool"/>
+          <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature|ZoomToChildFeature"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
-      <attributeEditorRelation relation="studyarea_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Study Area" relationWidgetTypeId="relation_editor" nmRelationId="" name="studyarea_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="1" forceSuppressFormPopup="0">
+      <attributeEditorRelation forceSuppressFormPopup="0" name="studyarea_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Study Area" relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="1" relation="studyarea_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
         <editor_configuration type="Map">
-          <Option value="AddChildFeature|DeleteChildFeature|ZoomToChildFeature" name="buttons" type="QString"/>
-          <Option value="true" name="show_first_feature" type="bool"/>
+          <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature|ZoomToChildFeature"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
       <attributeEditorField name="municipality" index="5" showLabel="1"/>
     </attributeEditorContainer>
-    <attributeEditorContainer columnCount="1" name="Kontakte" visibilityExpression="" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
-      <attributeEditorRelation relation="assetitem_contact_author_authoredassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Autor" relationWidgetTypeId="relation_editor" nmRelationId="assetitem_contact_author_author_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" name="assetitem_contact_author_authoredassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="1" forceSuppressFormPopup="0">
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Kontakte" columnCount="1" groupBox="0" showLabel="1">
+      <attributeEditorRelation forceSuppressFormPopup="0" name="assetitem_contact_author_authoredassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Autor" relationWidgetTypeId="relation_editor" nmRelationId="assetitem_contact_author_author_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" showLabel="1" relation="assetitem_contact_author_authoredassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
         <editor_configuration type="Map">
-          <Option value="Link|Unlink|AddChildFeature|DeleteChildFeature" name="buttons" type="QString"/>
-          <Option value="true" name="show_first_feature" type="bool"/>
+          <Option name="buttons" type="QString" value="Link|Unlink|AddChildFeature|DeleteChildFeature"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
-      <attributeEditorRelation relation="assetitem_contact_supplier_suppliedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Supplier" relationWidgetTypeId="relation_editor" nmRelationId="assetitem_contact_supplier_supplier_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" name="assetitem_contact_supplier_suppliedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="1" forceSuppressFormPopup="0">
+      <attributeEditorRelation forceSuppressFormPopup="0" name="assetitem_contact_supplier_suppliedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Supplier" relationWidgetTypeId="relation_editor" nmRelationId="assetitem_contact_supplier_supplier_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" showLabel="1" relation="assetitem_contact_supplier_suppliedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
         <editor_configuration type="Map">
-          <Option value="Link|Unlink|AddChildFeature|DeleteChildFeature" name="buttons" type="QString"/>
-          <Option value="true" name="show_first_feature" type="bool"/>
+          <Option name="buttons" type="QString" value="Link|Unlink|AddChildFeature|DeleteChildFeature"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
-      <attributeEditorRelation relation="assetitem_contact_initiator_initiatedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Initiator" relationWidgetTypeId="relation_editor" nmRelationId="assetitem_contact_initiator_initiator_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" name="assetitem_contact_initiator_initiatedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="1" forceSuppressFormPopup="0">
+      <attributeEditorRelation forceSuppressFormPopup="0" name="assetitem_contact_initiator_initiatedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Initiator" relationWidgetTypeId="relation_editor" nmRelationId="assetitem_contact_initiator_initiator_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" showLabel="1" relation="assetitem_contact_initiator_initiatedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
         <editor_configuration type="Map">
-          <Option value="Link|Unlink|AddChildFeature|DeleteChildFeature" name="buttons" type="QString"/>
-          <Option value="true" name="show_first_feature" type="bool"/>
+          <Option name="buttons" type="QString" value="Link|Unlink|AddChildFeature|DeleteChildFeature"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer columnCount="2" name="Pfade" visibilityExpression="" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
-      <attributeEditorContainer columnCount="1" name="Ablagen" visibilityExpression="" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Pfade *" columnCount="2" groupBox="0" showLabel="1">
+      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Ablagen" columnCount="1" groupBox="1" showLabel="1">
         <attributeEditorField name="url" index="6" showLabel="1"/>
         <attributeEditorField name="relativepath" index="7" showLabel="1"/>
         <attributeEditorField name="locationanalog" index="8" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer columnCount="1" name="Rechtliche Dokumente" visibilityExpression="" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
-        <attributeEditorRelation relation="legaldoc_lg_glssts_vssts_ssttem_legaldoc_lg_geolssts_v2geolassets_assetitem_T_Id" label="" relationWidgetTypeId="relation_editor" nmRelationId="" name="legaldoc_lg_glssts_vssts_ssttem_legaldoc_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="0" forceSuppressFormPopup="0">
+      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Rechtliche Dokumente" columnCount="1" groupBox="1" showLabel="1">
+        <attributeEditorRelation forceSuppressFormPopup="0" name="legaldoc_lg_glssts_vssts_ssttem_legaldoc_lg_geolssts_v2geolassets_assetitem_T_Id" label="" relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="0" relation="legaldoc_lg_glssts_vssts_ssttem_legaldoc_lg_geolssts_v2geolassets_assetitem_T_Id">
           <editor_configuration type="Map">
-            <Option value="AddChildFeature|DeleteChildFeature" name="buttons" type="QString"/>
-            <Option value="true" name="show_first_feature" type="bool"/>
+            <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature"/>
+            <Option name="show_first_feature" type="bool" value="true"/>
           </editor_configuration>
         </attributeEditorRelation>
       </attributeEditorContainer>
     </attributeEditorContainer>
-    <attributeEditorContainer columnCount="1" name="Publikationen" visibilityExpression="" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
-      <attributeEditorRelation relation="assetitem_publication_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="" relationWidgetTypeId="relation_editor" nmRelationId="assetitem_publication_publication_publication_T_Id" name="assetitem_publication_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="0" forceSuppressFormPopup="0">
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Publikationen" columnCount="1" groupBox="0" showLabel="1">
+      <attributeEditorRelation forceSuppressFormPopup="0" name="assetitem_publication_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="" relationWidgetTypeId="relation_editor" nmRelationId="assetitem_publication_publication_publication_T_Id" showLabel="0" relation="assetitem_publication_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
         <editor_configuration type="Map">
-          <Option value="Link|Unlink|AddChildFeature|DeleteChildFeature|ZoomToChildFeature" name="buttons" type="QString"/>
-          <Option value="true" name="show_first_feature" type="bool"/>
+          <Option name="buttons" type="QString" value="Link|Unlink|AddChildFeature|DeleteChildFeature|ZoomToChildFeature"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer columnCount="1" name="Referenzierte Assets" visibilityExpression="" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
-      <attributeEditorRelation relation="assetitemx_assetitemy_assetitemy_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Verlinkte Assets " relationWidgetTypeId="relation_editor" nmRelationId="" name="assetitemx_assetitemy_assetitemy_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="1" forceSuppressFormPopup="0">
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Referenzierte Assets" columnCount="1" groupBox="0" showLabel="1">
+      <attributeEditorRelation forceSuppressFormPopup="0" name="assetitemx_assetitemy_assetitemy_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Verlinkte Assets " relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="1" relation="assetitemx_assetitemy_assetitemy_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
         <editor_configuration type="Map">
-          <Option value="AddChildFeature|DeleteChildFeature" name="buttons" type="QString"/>
-          <Option value="false" name="show_first_feature" type="bool"/>
+          <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature"/>
+          <Option name="show_first_feature" type="bool" value="false"/>
         </editor_configuration>
       </attributeEditorRelation>
-      <attributeEditorRelation relation="assetitemx_assetitemy_assetitemx_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Assets, die auf diesen Asset verlinken" relationWidgetTypeId="relation_editor" nmRelationId="" name="assetitemx_assetitemy_assetitemx_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="1" forceSuppressFormPopup="0">
+      <attributeEditorRelation forceSuppressFormPopup="0" name="assetitemx_assetitemy_assetitemx_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Assets, die auf diesen Asset verlinken" relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="1" relation="assetitemx_assetitemy_assetitemx_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
         <editor_configuration type="Map">
-          <Option value="NoButton" name="buttons" type="QString"/>
-          <Option value="false" name="show_first_feature" type="bool"/>
-        </editor_configuration>
-      </attributeEditorRelation>
-    </attributeEditorContainer>
-    <attributeEditorContainer columnCount="1" name="Interne Projekte" visibilityExpression="" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
-      <attributeEditorRelation relation="assetitem_usedby_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="" relationWidgetTypeId="relation_editor" nmRelationId="assetitem_usedby_usedby_internalproject_T_Id" name="assetitem_usedby_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="0" forceSuppressFormPopup="0">
-        <editor_configuration type="Map">
-          <Option value="Link|Unlink|SaveChildEdits|AddChildFeature|DeleteChildFeature" name="buttons" type="QString"/>
-          <Option value="true" name="show_first_feature" type="bool"/>
+          <Option name="buttons" type="QString" value="NoButton"/>
+          <Option name="show_first_feature" type="bool" value="false"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer columnCount="1" name="Info KI" visibilityExpression="" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Interne Projekte" columnCount="1" groupBox="0" showLabel="1">
+      <attributeEditorRelation forceSuppressFormPopup="0" name="assetitem_usedby_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="" relationWidgetTypeId="relation_editor" nmRelationId="assetitem_usedby_usedby_internalproject_T_Id" showLabel="0" relation="assetitem_usedby_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
+        <editor_configuration type="Map">
+          <Option name="buttons" type="QString" value="Link|Unlink|SaveChildEdits|AddChildFeature|DeleteChildFeature"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Info KI" columnCount="1" groupBox="0" showLabel="1">
       <attributeEditorField name="textbody" index="11" showLabel="1"/>
-      <attributeEditorRelation relation="autocat_lg_glssts_vssts_ssttem_autocatlabel_lg_geolssts_v2geolassets_assetitem_T_Id" label="Automatisch zugewiesene Klasse  (genau ein Eintrag)" relationWidgetTypeId="relation_editor" nmRelationId="" name="autocat_lg_glssts_vssts_ssttem_autocatlabel_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="1" forceSuppressFormPopup="0">
+      <attributeEditorRelation forceSuppressFormPopup="0" name="autocat_lg_glssts_vssts_ssttem_autocatlabel_lg_geolssts_v2geolassets_assetitem_T_Id" label="Automatisch zugewiesene Klasse" relationWidgetTypeId="linking_relation_editor" nmRelationId="one_to_one" showLabel="1" relation="autocat_lg_glssts_vssts_ssttem_autocatlabel_lg_geolssts_v2geolassets_assetitem_T_Id">
         <editor_configuration type="Map">
-          <Option value="AllButtons" name="buttons" type="QString"/>
-          <Option value="true" name="show_first_feature" type="bool"/>
+          <Option name="buttons" type="QString" value="AllButtons"/>
+          <Option name="one_to_one" type="bool" value="true"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer columnCount="1" name="InfoGeol" visibilityExpression="" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="InfoGeol" columnCount="1" groupBox="0" showLabel="1">
       <attributeEditorField name="infogeoldata" index="14" showLabel="1"/>
       <attributeEditorField name="infogeolcontactdata" index="15" showLabel="1"/>
       <attributeEditorField name="infogeolauxdata" index="16" showLabel="1"/>
     </attributeEditorContainer>
-    <attributeEditorContainer columnCount="2" name="Administration" visibilityExpression="" showLabel="1" groupBox="0" visibilityExpressionEnabled="0">
-      <attributeEditorContainer columnCount="1" name="Bearbeitung" visibilityExpression="" showLabel="1" groupBox="1" visibilityExpressionEnabled="0">
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Administration *" columnCount="2" groupBox="0" showLabel="1">
+      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Bearbeitung" columnCount="1" groupBox="1" showLabel="1">
         <attributeEditorField name="datereceipt" index="4" showLabel="1"/>
         <attributeEditorField name="processor" index="9" showLabel="1"/>
         <attributeEditorField name="datelastprocessed" index="10" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer columnCount="1" name="Bearbeitungsstatus (mindestens ein Eintrag)" visibilityExpression="" showLabel="1" backgroundColor="#ffe0b2" groupBox="1" visibilityExpressionEnabled="0">
-        <attributeEditorRelation relation="statuswork_lg_glssts_vssts_ssttem_statuswork_lg_geolssts_v2geolassets_assetitem_T_Id" label="" relationWidgetTypeId="relation_editor" nmRelationId="" name="statuswork_lg_glssts_vssts_ssttem_statuswork_lg_geolssts_v2geolassets_assetitem_T_Id" showLabel="0" forceSuppressFormPopup="0">
+      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" backgroundColor="#ffe0b2" name="Bearbeitungsstatus (mindestens ein Eintrag)" columnCount="1" groupBox="1" showLabel="1">
+        <attributeEditorRelation forceSuppressFormPopup="0" name="statuswork_lg_glssts_vssts_ssttem_statuswork_lg_geolssts_v2geolassets_assetitem_T_Id" label="" relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="0" relation="statuswork_lg_glssts_vssts_ssttem_statuswork_lg_geolssts_v2geolassets_assetitem_T_Id">
           <editor_configuration type="Map">
-            <Option value="AddChildFeature|DeleteChildFeature" name="buttons" type="QString"/>
-            <Option value="true" name="show_first_feature" type="bool"/>
+            <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature"/>
+            <Option name="show_first_feature" type="bool" value="true"/>
           </editor_configuration>
         </attributeEditorRelation>
       </attributeEditorContainer>
     </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpressionEnabled="1" visibilityExpression="NOT isextract" name="Teilassets" columnCount="1" groupBox="0" showLabel="1">
+      <attributeEditorField name="Teilasset Info" index="29" showLabel="0"/>
+      <attributeEditorRelation forceSuppressFormPopup="0" name="lg_geolssts_v2geolassets_assetitem_assetitemmain_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Verknüpfte Teilassets" relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="1" relation="lg_geolssts_v2geolassets_assetitem_assetitemmain_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
+        <editor_configuration type="Map">
+          <Option name="buttons" type="QString" value="Link|Unlink|AddChildFeature|DeleteChildFeature"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+      <attributeEditorRelation forceSuppressFormPopup="0" name="assetkindref_lg_glssts_vssts_ssttem_assetcomposition_lg_geolssts_v2geolassets_assetitem_T_Id" label="Arten der Teilassets" relationWidgetTypeId="relation_editor" nmRelationId="assetkindref_areference_assetkinditem_T_Id" showLabel="1" relation="assetkindref_lg_glssts_vssts_ssttem_assetcomposition_lg_geolssts_v2geolassets_assetitem_T_Id">
+        <editor_configuration type="Map">
+          <Option name="buttons" type="QString" value="Link|Unlink"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field editable="1" name="T_Id"/>
-    <field editable="1" name="T_Ili_Tid"/>
-    <field editable="1" name="T_basket"/>
-    <field editable="1" name="adescription"/>
-    <field editable="1" name="aformat"/>
-    <field editable="1" name="akind"/>
-    <field editable="1" name="alanguage"/>
-    <field editable="1" name="assetitemmain_assetitem"/>
-    <field editable="1" name="assetitemmain_lg_geolssts_v2geolassets_assetitem"/>
-    <field editable="1" name="authorbiblio"/>
-    <field editable="1" name="datecreation"/>
-    <field editable="1" name="datelastprocessed"/>
-    <field editable="1" name="datereceipt"/>
-    <field editable="1" name="formatcomposition"/>
-    <field editable="1" name="idsgs"/>
-    <field editable="1" name="infogeolauxdata"/>
-    <field editable="1" name="infogeolcontactdata"/>
-    <field editable="1" name="infogeoldata"/>
-    <field editable="1" name="isextract"/>
-    <field editable="1" name="isnatrel"/>
-    <field editable="1" name="locationanalog"/>
-    <field editable="1" name="municipality"/>
-    <field editable="1" name="processor"/>
-    <field editable="1" name="relativepath"/>
-    <field editable="1" name="remark"/>
-    <field editable="1" name="sourceproject"/>
-    <field editable="1" name="textbody"/>
-    <field editable="1" name="titleoriginal"/>
-    <field editable="1" name="titlepublic"/>
-    <field editable="1" name="url"/>
+    <field name="T_Id" editable="1"/>
+    <field name="T_Ili_Tid" editable="1"/>
+    <field name="T_basket" editable="1"/>
+    <field name="Teilasset Info" editable="0"/>
+    <field name="adescription" editable="1"/>
+    <field name="aformat" editable="1"/>
+    <field name="akind" editable="1"/>
+    <field name="alanguage" editable="1"/>
+    <field name="assetitemmain_assetitem" editable="1"/>
+    <field name="assetitemmain_lg_geolssts_v2geolassets_assetitem" editable="1"/>
+    <field name="authorbiblio" editable="1"/>
+    <field name="datecreation" editable="1"/>
+    <field name="datelastprocessed" editable="1"/>
+    <field name="datereceipt" editable="1"/>
+    <field name="formatcomposition" editable="1"/>
+    <field name="idsgs" editable="1"/>
+    <field name="infogeolauxdata" editable="1"/>
+    <field name="infogeolcontactdata" editable="1"/>
+    <field name="infogeoldata" editable="1"/>
+    <field name="isextract" editable="1"/>
+    <field name="isnatrel" editable="1"/>
+    <field name="locationanalog" editable="1"/>
+    <field name="municipality" editable="1"/>
+    <field name="processor" editable="1"/>
+    <field name="relativepath" editable="1"/>
+    <field name="remark" editable="1"/>
+    <field name="sourceproject" editable="1"/>
+    <field name="textbody" editable="1"/>
+    <field name="titleoriginal" editable="1"/>
+    <field name="titlepublic" editable="1"/>
+    <field name="url" editable="1"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="T_Id"/>
-    <field labelOnTop="0" name="T_Ili_Tid"/>
-    <field labelOnTop="0" name="T_basket"/>
-    <field labelOnTop="0" name="adescription"/>
-    <field labelOnTop="0" name="aformat"/>
-    <field labelOnTop="0" name="akind"/>
-    <field labelOnTop="0" name="alanguage"/>
-    <field labelOnTop="0" name="assetitemmain_assetitem"/>
-    <field labelOnTop="0" name="assetitemmain_lg_geolssts_v2geolassets_assetitem"/>
-    <field labelOnTop="0" name="authorbiblio"/>
-    <field labelOnTop="0" name="datecreation"/>
-    <field labelOnTop="0" name="datelastprocessed"/>
-    <field labelOnTop="0" name="datereceipt"/>
-    <field labelOnTop="0" name="formatcomposition"/>
-    <field labelOnTop="0" name="idsgs"/>
-    <field labelOnTop="0" name="infogeolauxdata"/>
-    <field labelOnTop="0" name="infogeolcontactdata"/>
-    <field labelOnTop="0" name="infogeoldata"/>
-    <field labelOnTop="0" name="isextract"/>
-    <field labelOnTop="0" name="isnatrel"/>
-    <field labelOnTop="0" name="locationanalog"/>
-    <field labelOnTop="0" name="municipality"/>
-    <field labelOnTop="0" name="processor"/>
-    <field labelOnTop="0" name="relativepath"/>
-    <field labelOnTop="0" name="remark"/>
-    <field labelOnTop="0" name="sourceproject"/>
-    <field labelOnTop="0" name="textbody"/>
-    <field labelOnTop="0" name="titleoriginal"/>
-    <field labelOnTop="0" name="titlepublic"/>
-    <field labelOnTop="0" name="url"/>
+    <field name="T_Id" labelOnTop="0"/>
+    <field name="T_Ili_Tid" labelOnTop="0"/>
+    <field name="T_basket" labelOnTop="0"/>
+    <field name="Teilasset Info" labelOnTop="0"/>
+    <field name="adescription" labelOnTop="0"/>
+    <field name="aformat" labelOnTop="0"/>
+    <field name="akind" labelOnTop="0"/>
+    <field name="alanguage" labelOnTop="0"/>
+    <field name="assetitemmain_assetitem" labelOnTop="0"/>
+    <field name="assetitemmain_lg_geolssts_v2geolassets_assetitem" labelOnTop="1"/>
+    <field name="authorbiblio" labelOnTop="0"/>
+    <field name="datecreation" labelOnTop="0"/>
+    <field name="datelastprocessed" labelOnTop="0"/>
+    <field name="datereceipt" labelOnTop="0"/>
+    <field name="formatcomposition" labelOnTop="0"/>
+    <field name="idsgs" labelOnTop="0"/>
+    <field name="infogeolauxdata" labelOnTop="0"/>
+    <field name="infogeolcontactdata" labelOnTop="0"/>
+    <field name="infogeoldata" labelOnTop="0"/>
+    <field name="isextract" labelOnTop="0"/>
+    <field name="isnatrel" labelOnTop="0"/>
+    <field name="locationanalog" labelOnTop="0"/>
+    <field name="municipality" labelOnTop="0"/>
+    <field name="processor" labelOnTop="0"/>
+    <field name="relativepath" labelOnTop="0"/>
+    <field name="remark" labelOnTop="0"/>
+    <field name="sourceproject" labelOnTop="0"/>
+    <field name="textbody" labelOnTop="0"/>
+    <field name="titleoriginal" labelOnTop="0"/>
+    <field name="titlepublic" labelOnTop="0"/>
+    <field name="url" labelOnTop="0"/>
   </labelOnTop>
   <reuseLastValue>
     <field name="T_Id" reuseLastValue="0"/>
     <field name="T_Ili_Tid" reuseLastValue="0"/>
     <field name="T_basket" reuseLastValue="0"/>
+    <field name="Teilasset Info" reuseLastValue="0"/>
     <field name="adescription" reuseLastValue="0"/>
     <field name="aformat" reuseLastValue="0"/>
     <field name="akind" reuseLastValue="0"/>
@@ -859,80 +889,80 @@ def my_form_open(dialog, layer, feature):
   <widgets>
     <widget name="assetitem_assetitemmain_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
       <config type="Map">
-        <Option value="false" name="force-suppress-popup" type="bool"/>
+        <Option name="force-suppress-popup" type="bool" value="false"/>
         <Option name="nm-rel" type="invalid"/>
       </config>
     </widget>
     <widget name="assetitem_contact_author_authoredassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
       <config type="Map">
-        <Option value="assetitem_contact_author_author_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" name="nm-rel" type="QString"/>
+        <Option name="nm-rel" type="QString" value="assetitem_contact_author_author_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id"/>
       </config>
     </widget>
     <widget name="assetitem_contact_author_authoredassetitem_lgassetitem_lgassetitem_T_Id">
       <config type="Map">
-        <Option value="assetitem_contact_author_author_lgcontact_lgcontact_T_Id" name="nm-rel" type="QString"/>
+        <Option name="nm-rel" type="QString" value="assetitem_contact_author_author_lgcontact_lgcontact_T_Id"/>
       </config>
     </widget>
     <widget name="assetitem_contact_initiator_initiatedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
       <config type="Map">
-        <Option value="assetitem_contact_initiator_initiator_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" name="nm-rel" type="QString"/>
+        <Option name="nm-rel" type="QString" value="assetitem_contact_initiator_initiator_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id"/>
       </config>
     </widget>
     <widget name="assetitem_contact_initiator_initiatedassetitem_lgassetitem_lgassetitem_T_Id">
       <config type="Map">
-        <Option value="assetitem_contact_initiator_initiator_lgcontact_lgcontact_T_Id" name="nm-rel" type="QString"/>
+        <Option name="nm-rel" type="QString" value="assetitem_contact_initiator_initiator_lgcontact_lgcontact_T_Id"/>
       </config>
     </widget>
     <widget name="assetitem_contact_supplier_suppliedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
       <config type="Map">
-        <Option value="assetitem_contact_supplier_supplier_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" name="nm-rel" type="QString"/>
+        <Option name="nm-rel" type="QString" value="assetitem_contact_supplier_supplier_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id"/>
       </config>
     </widget>
     <widget name="assetitem_contact_supplier_suppliedassetitem_lgassetitem_lgassetitem_T_Id">
       <config type="Map">
-        <Option value="assetitem_contact_supplier_supplier_lgcontact_lgcontact_T_Id" name="nm-rel" type="QString"/>
+        <Option name="nm-rel" type="QString" value="assetitem_contact_supplier_supplier_lgcontact_lgcontact_T_Id"/>
       </config>
     </widget>
     <widget name="assetitem_publication_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
       <config type="Map">
-        <Option value="assetitem_publication_publication_publication_T_Id" name="nm-rel" type="QString"/>
+        <Option name="nm-rel" type="QString" value="assetitem_publication_publication_publication_T_Id"/>
       </config>
     </widget>
     <widget name="assetitem_usedby_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
       <config type="Map">
-        <Option value="assetitem_usedby_usedby_internalproject_T_Id" name="nm-rel" type="QString"/>
+        <Option name="nm-rel" type="QString" value="assetitem_usedby_usedby_internalproject_T_Id"/>
       </config>
     </widget>
     <widget name="assetitemx_assetitemy_assetitemx_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
       <config type="Map">
-        <Option value="false" name="force-suppress-popup" type="bool"/>
+        <Option name="force-suppress-popup" type="bool" value="false"/>
         <Option name="nm-rel" type="invalid"/>
       </config>
     </widget>
     <widget name="assetitemx_assetitemy_assetitemx_lgassetitem_lgassetitem_T_Id">
       <config type="Map">
-        <Option value="assetitemx_assetitemy_assetitemy_lgassetitem_lgassetitem_T_Id" name="nm-rel" type="QString"/>
+        <Option name="nm-rel" type="QString" value="assetitemx_assetitemy_assetitemy_lgassetitem_lgassetitem_T_Id"/>
       </config>
     </widget>
     <widget name="assetitemx_assetitemy_assetitemy_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
       <config type="Map">
-        <Option value="assetitemx_assetitemy_assetitemy_assetitem_assetitem_T_Id" name="nm-rel" type="QString"/>
+        <Option name="nm-rel" type="QString" value="assetitemx_assetitemy_assetitemy_assetitem_assetitem_T_Id"/>
       </config>
     </widget>
     <widget name="assetitemx_assetitemy_assetitemy_lgassetitem_lgassetitem_T_Id">
       <config type="Map">
-        <Option value="assetitemx_assetitemy_assetitemx_lgassetitem_lgassetitem_T_Id" name="nm-rel" type="QString"/>
+        <Option name="nm-rel" type="QString" value="assetitemx_assetitemy_assetitemx_lgassetitem_lgassetitem_T_Id"/>
       </config>
     </widget>
     <widget name="lg_geolssts_v2geolassets_assetitem_assetitemmain_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
       <config type="Map">
-        <Option value="false" name="force-suppress-popup" type="bool"/>
+        <Option name="force-suppress-popup" type="bool" value="false"/>
         <Option name="nm-rel" type="invalid"/>
       </config>
     </widget>
     <widget name="lgassetitem_publication_lgassetitem_lgassetitem_T_Id">
       <config type="Map">
-        <Option value="lgassetitem_publication_publication_publication_T_Id" name="nm-rel" type="QString"/>
+        <Option name="nm-rel" type="QString" value="lgassetitem_publication_publication_publication_T_Id"/>
       </config>
     </widget>
   </widgets>

--- a/lg_geolassets_v2/layerstyle/assetkinditem.qml
+++ b/lg_geolassets_v2/layerstyle/assetkinditem.qml
@@ -1,264 +1,263 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="Fields|Forms" version="3.25.0-Master">
+<qgis readOnly="1" styleCategories="LayerConfiguration|Fields|Forms" version="3.24.3-Tisler">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id">
+    <field name="T_Id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_basket">
+    <field name="T_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="AllowAddFeatures"/>
-            <Option type="bool" value="true" name="AllowNULL"/>
-            <Option type="bool" value="false" name="ChainFilters"/>
-            <Option type="QString" value="&quot;topic&quot; = 'GeolAssetsCatalogues_V2.Catalogues' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option type="bool" value="false" name="MapIdentification"/>
-            <Option type="bool" value="true" name="OrderByValue"/>
-            <Option type="bool" value="false" name="ReadOnly"/>
-            <Option type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" name="ReferencedLayerDataSource"/>
-            <Option type="QString" value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" name="ReferencedLayerId"/>
-            <Option type="QString" value="T_ILI2DB_BASKET" name="ReferencedLayerName"/>
-            <Option type="QString" value="ogr" name="ReferencedLayerProviderKey"/>
-            <Option type="QString" value="assetkinditem_T_basket_T_ILI2DB_BASKET_T_Id" name="Relation"/>
-            <Option type="bool" value="false" name="ShowForm"/>
-            <Option type="bool" value="false" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; = 'GeolAssetsCatalogues_V2.Catalogues' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="Relation" type="QString" value="assetkinditem_T_basket_T_ILI2DB_BASKET_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_Ili_Tid">
+    <field name="T_Ili_Tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="acode">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="geolcode">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname_de">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname_fr">
+    <field name="acode" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="aname_rm">
+    <field name="geolcode" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="aname_it">
+    <field name="aname" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="aname_en">
+    <field name="aname_de" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription">
+    <field name="aname_fr" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription_de">
+    <field name="aname_rm" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription_fr">
+    <field name="aname_it" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option type="bool" value="false" name="IsMultiline"/>
-            <Option type="bool" value="false" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription_rm">
+    <field name="aname_en" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="adescription" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription_it">
+    <field name="adescription_de" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="adescription_fr" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="adescription_rm" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription_en">
+    <field name="adescription_it" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="issuperitem">
+    <field name="adescription_en" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="issuperitem" configurationFlags="None">
       <editWidget type="CheckBox">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="isuseable">
+    <field name="isuseable" configurationFlags="None">
       <editWidget type="CheckBox">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_statusworkitem">
+    <field name="parent_statusworkitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_natrelitem">
+    <field name="parent_assetkinditem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_languageitem">
+    <field name="parent_languageitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_legaldocitem">
+    <field name="parent_natrelitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_assetkinditem">
+    <field name="parent_mancatlabelitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_statusassetuseitem">
+    <field name="parent_autocatlabelitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_autoobjectcatitem">
+    <field name="parent_contactkinditem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_contactkinditem">
+    <field name="parent_assetformatitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_assetformatitem">
+    <field name="parent_statusassetuseitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_mancatlabelitem">
+    <field name="parent_legaldocitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_autocatlabelitem">
+    <field name="parent_geomqualityitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_pubchannelitem">
+    <field name="parent_autoobjectcatitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_geomqualityitem">
+    <field name="parent_pubchannelitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
@@ -267,140 +266,140 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias index="0" field="T_Id" name=""/>
-    <alias index="1" field="T_basket" name=""/>
-    <alias index="2" field="T_Ili_Tid" name=""/>
-    <alias index="3" field="acode" name="Code"/>
-    <alias index="4" field="geolcode" name="GeolCode"/>
-    <alias index="5" field="aname" name="Name"/>
-    <alias index="6" field="aname_de" name=""/>
-    <alias index="7" field="aname_fr" name=""/>
-    <alias index="8" field="aname_rm" name=""/>
-    <alias index="9" field="aname_it" name=""/>
-    <alias index="10" field="aname_en" name=""/>
-    <alias index="11" field="adescription" name="Description"/>
-    <alias index="12" field="adescription_de" name=""/>
-    <alias index="13" field="adescription_fr" name=""/>
-    <alias index="14" field="adescription_rm" name=""/>
-    <alias index="15" field="adescription_it" name=""/>
-    <alias index="16" field="adescription_en" name=""/>
-    <alias index="17" field="issuperitem" name="IsSuperItem"/>
-    <alias index="18" field="isuseable" name="IsUseable"/>
-    <alias index="19" field="parent_statusworkitem" name="Parent"/>
-    <alias index="20" field="parent_natrelitem" name="Parent"/>
-    <alias index="21" field="parent_languageitem" name="Parent"/>
-    <alias index="22" field="parent_legaldocitem" name="Parent"/>
-    <alias index="23" field="parent_assetkinditem" name="Parent"/>
-    <alias index="24" field="parent_statusassetuseitem" name="Parent"/>
-    <alias index="25" field="parent_autoobjectcatitem" name="Parent"/>
-    <alias index="26" field="parent_contactkinditem" name="Parent"/>
-    <alias index="27" field="parent_assetformatitem" name="Parent"/>
-    <alias index="28" field="parent_mancatlabelitem" name="Parent"/>
-    <alias index="29" field="parent_autocatlabelitem" name="Parent"/>
-    <alias index="30" field="parent_pubchannelitem" name="Parent"/>
-    <alias index="31" field="parent_geomqualityitem" name="Parent"/>
+    <alias name="" field="T_Id" index="0"/>
+    <alias name="" field="T_basket" index="1"/>
+    <alias name="" field="T_Ili_Tid" index="2"/>
+    <alias name="Code" field="acode" index="3"/>
+    <alias name="GeolCode" field="geolcode" index="4"/>
+    <alias name="Name" field="aname" index="5"/>
+    <alias name="" field="aname_de" index="6"/>
+    <alias name="" field="aname_fr" index="7"/>
+    <alias name="" field="aname_rm" index="8"/>
+    <alias name="" field="aname_it" index="9"/>
+    <alias name="" field="aname_en" index="10"/>
+    <alias name="Description" field="adescription" index="11"/>
+    <alias name="" field="adescription_de" index="12"/>
+    <alias name="" field="adescription_fr" index="13"/>
+    <alias name="" field="adescription_rm" index="14"/>
+    <alias name="" field="adescription_it" index="15"/>
+    <alias name="" field="adescription_en" index="16"/>
+    <alias name="IsSuperItem" field="issuperitem" index="17"/>
+    <alias name="IsUseable" field="isuseable" index="18"/>
+    <alias name="Parent" field="parent_statusworkitem" index="19"/>
+    <alias name="Parent" field="parent_assetkinditem" index="20"/>
+    <alias name="Parent" field="parent_languageitem" index="21"/>
+    <alias name="Parent" field="parent_natrelitem" index="22"/>
+    <alias name="Parent" field="parent_mancatlabelitem" index="23"/>
+    <alias name="Parent" field="parent_autocatlabelitem" index="24"/>
+    <alias name="Parent" field="parent_contactkinditem" index="25"/>
+    <alias name="Parent" field="parent_assetformatitem" index="26"/>
+    <alias name="Parent" field="parent_statusassetuseitem" index="27"/>
+    <alias name="Parent" field="parent_legaldocitem" index="28"/>
+    <alias name="Parent" field="parent_geomqualityitem" index="29"/>
+    <alias name="Parent" field="parent_autoobjectcatitem" index="30"/>
+    <alias name="Parent" field="parent_pubchannelitem" index="31"/>
   </aliases>
   <defaults>
-    <default field="T_Id" applyOnUpdate="0" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
-    <default field="T_basket" applyOnUpdate="0" expression="@default_basket_geolassetscatalogues_v2_catalogues"/>
-    <default field="T_Ili_Tid" applyOnUpdate="0" expression="substr(uuid(), 2, 36)"/>
-    <default field="acode" applyOnUpdate="0" expression=""/>
-    <default field="geolcode" applyOnUpdate="0" expression=""/>
-    <default field="aname" applyOnUpdate="0" expression=""/>
-    <default field="aname_de" applyOnUpdate="0" expression=""/>
-    <default field="aname_fr" applyOnUpdate="0" expression=""/>
-    <default field="aname_rm" applyOnUpdate="0" expression=""/>
-    <default field="aname_it" applyOnUpdate="0" expression=""/>
-    <default field="aname_en" applyOnUpdate="0" expression=""/>
-    <default field="adescription" applyOnUpdate="0" expression=""/>
-    <default field="adescription_de" applyOnUpdate="0" expression=""/>
-    <default field="adescription_fr" applyOnUpdate="0" expression=""/>
-    <default field="adescription_rm" applyOnUpdate="0" expression=""/>
-    <default field="adescription_it" applyOnUpdate="0" expression=""/>
-    <default field="adescription_en" applyOnUpdate="0" expression=""/>
-    <default field="issuperitem" applyOnUpdate="0" expression=""/>
-    <default field="isuseable" applyOnUpdate="0" expression=""/>
-    <default field="parent_statusworkitem" applyOnUpdate="0" expression=""/>
-    <default field="parent_natrelitem" applyOnUpdate="0" expression=""/>
-    <default field="parent_languageitem" applyOnUpdate="0" expression=""/>
-    <default field="parent_legaldocitem" applyOnUpdate="0" expression=""/>
-    <default field="parent_assetkinditem" applyOnUpdate="0" expression=""/>
-    <default field="parent_statusassetuseitem" applyOnUpdate="0" expression=""/>
-    <default field="parent_autoobjectcatitem" applyOnUpdate="0" expression=""/>
-    <default field="parent_contactkinditem" applyOnUpdate="0" expression=""/>
-    <default field="parent_assetformatitem" applyOnUpdate="0" expression=""/>
-    <default field="parent_mancatlabelitem" applyOnUpdate="0" expression=""/>
-    <default field="parent_autocatlabelitem" applyOnUpdate="0" expression=""/>
-    <default field="parent_pubchannelitem" applyOnUpdate="0" expression=""/>
-    <default field="parent_geomqualityitem" applyOnUpdate="0" expression=""/>
+    <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
+    <default field="T_basket" expression="@default_basket_geolassetscatalogues_v2_catalogues" applyOnUpdate="0"/>
+    <default field="T_Ili_Tid" expression="substr(uuid(), 2, 36)" applyOnUpdate="0"/>
+    <default field="acode" expression="" applyOnUpdate="0"/>
+    <default field="geolcode" expression="" applyOnUpdate="0"/>
+    <default field="aname" expression="" applyOnUpdate="0"/>
+    <default field="aname_de" expression="" applyOnUpdate="0"/>
+    <default field="aname_fr" expression="" applyOnUpdate="0"/>
+    <default field="aname_rm" expression="" applyOnUpdate="0"/>
+    <default field="aname_it" expression="" applyOnUpdate="0"/>
+    <default field="aname_en" expression="" applyOnUpdate="0"/>
+    <default field="adescription" expression="" applyOnUpdate="0"/>
+    <default field="adescription_de" expression="" applyOnUpdate="0"/>
+    <default field="adescription_fr" expression="" applyOnUpdate="0"/>
+    <default field="adescription_rm" expression="" applyOnUpdate="0"/>
+    <default field="adescription_it" expression="" applyOnUpdate="0"/>
+    <default field="adescription_en" expression="" applyOnUpdate="0"/>
+    <default field="issuperitem" expression="" applyOnUpdate="0"/>
+    <default field="isuseable" expression="" applyOnUpdate="0"/>
+    <default field="parent_statusworkitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_assetkinditem" expression="" applyOnUpdate="0"/>
+    <default field="parent_languageitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_natrelitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_mancatlabelitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_autocatlabelitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_contactkinditem" expression="" applyOnUpdate="0"/>
+    <default field="parent_assetformatitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_statusassetuseitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_legaldocitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_geomqualityitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_autoobjectcatitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_pubchannelitem" expression="" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint exp_strength="0" constraints="3" unique_strength="1" field="T_Id" notnull_strength="1"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" field="T_basket" notnull_strength="1"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="T_Ili_Tid" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" field="acode" notnull_strength="1"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="geolcode" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="aname" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="aname_de" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="aname_fr" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="aname_rm" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="aname_it" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="aname_en" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="adescription" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="adescription_de" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="adescription_fr" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="adescription_rm" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="adescription_it" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="adescription_en" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" field="issuperitem" notnull_strength="1"/>
-    <constraint exp_strength="0" constraints="1" unique_strength="0" field="isuseable" notnull_strength="1"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="parent_statusworkitem" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="parent_natrelitem" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="parent_languageitem" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="parent_legaldocitem" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="parent_assetkinditem" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="parent_statusassetuseitem" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="parent_autoobjectcatitem" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="parent_contactkinditem" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="parent_assetformatitem" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="parent_mancatlabelitem" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="parent_autocatlabelitem" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="parent_pubchannelitem" notnull_strength="0"/>
-    <constraint exp_strength="0" constraints="0" unique_strength="0" field="parent_geomqualityitem" notnull_strength="0"/>
+    <constraint constraints="3" field="T_Id" unique_strength="1" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="1" field="T_basket" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="T_Ili_Tid" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="1" field="acode" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="geolcode" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_de" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_fr" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_rm" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_it" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_en" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_de" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_fr" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_rm" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_it" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_en" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="1" field="issuperitem" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="1" field="isuseable" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="parent_statusworkitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_assetkinditem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_languageitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_natrelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_mancatlabelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_autocatlabelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_contactkinditem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_assetformatitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_statusassetuseitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_legaldocitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_geomqualityitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_autoobjectcatitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_pubchannelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="T_Id" exp="" desc=""/>
-    <constraint field="T_basket" exp="" desc=""/>
-    <constraint field="T_Ili_Tid" exp="" desc=""/>
-    <constraint field="acode" exp="" desc=""/>
-    <constraint field="geolcode" exp="" desc=""/>
-    <constraint field="aname" exp="" desc=""/>
-    <constraint field="aname_de" exp="" desc=""/>
-    <constraint field="aname_fr" exp="" desc=""/>
-    <constraint field="aname_rm" exp="" desc=""/>
-    <constraint field="aname_it" exp="" desc=""/>
-    <constraint field="aname_en" exp="" desc=""/>
-    <constraint field="adescription" exp="" desc=""/>
-    <constraint field="adescription_de" exp="" desc=""/>
-    <constraint field="adescription_fr" exp="" desc=""/>
-    <constraint field="adescription_rm" exp="" desc=""/>
-    <constraint field="adescription_it" exp="" desc=""/>
-    <constraint field="adescription_en" exp="" desc=""/>
-    <constraint field="issuperitem" exp="" desc=""/>
-    <constraint field="isuseable" exp="" desc=""/>
-    <constraint field="parent_statusworkitem" exp="" desc=""/>
-    <constraint field="parent_natrelitem" exp="" desc=""/>
-    <constraint field="parent_languageitem" exp="" desc=""/>
-    <constraint field="parent_legaldocitem" exp="" desc=""/>
-    <constraint field="parent_assetkinditem" exp="" desc=""/>
-    <constraint field="parent_statusassetuseitem" exp="" desc=""/>
-    <constraint field="parent_autoobjectcatitem" exp="" desc=""/>
-    <constraint field="parent_contactkinditem" exp="" desc=""/>
-    <constraint field="parent_assetformatitem" exp="" desc=""/>
-    <constraint field="parent_mancatlabelitem" exp="" desc=""/>
-    <constraint field="parent_autocatlabelitem" exp="" desc=""/>
-    <constraint field="parent_pubchannelitem" exp="" desc=""/>
-    <constraint field="parent_geomqualityitem" exp="" desc=""/>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="T_Ili_Tid" desc=""/>
+    <constraint exp="" field="acode" desc=""/>
+    <constraint exp="" field="geolcode" desc=""/>
+    <constraint exp="" field="aname" desc=""/>
+    <constraint exp="" field="aname_de" desc=""/>
+    <constraint exp="" field="aname_fr" desc=""/>
+    <constraint exp="" field="aname_rm" desc=""/>
+    <constraint exp="" field="aname_it" desc=""/>
+    <constraint exp="" field="aname_en" desc=""/>
+    <constraint exp="" field="adescription" desc=""/>
+    <constraint exp="" field="adescription_de" desc=""/>
+    <constraint exp="" field="adescription_fr" desc=""/>
+    <constraint exp="" field="adescription_rm" desc=""/>
+    <constraint exp="" field="adescription_it" desc=""/>
+    <constraint exp="" field="adescription_en" desc=""/>
+    <constraint exp="" field="issuperitem" desc=""/>
+    <constraint exp="" field="isuseable" desc=""/>
+    <constraint exp="" field="parent_statusworkitem" desc=""/>
+    <constraint exp="" field="parent_assetkinditem" desc=""/>
+    <constraint exp="" field="parent_languageitem" desc=""/>
+    <constraint exp="" field="parent_natrelitem" desc=""/>
+    <constraint exp="" field="parent_mancatlabelitem" desc=""/>
+    <constraint exp="" field="parent_autocatlabelitem" desc=""/>
+    <constraint exp="" field="parent_contactkinditem" desc=""/>
+    <constraint exp="" field="parent_assetformatitem" desc=""/>
+    <constraint exp="" field="parent_statusassetuseitem" desc=""/>
+    <constraint exp="" field="parent_legaldocitem" desc=""/>
+    <constraint exp="" field="parent_geomqualityitem" desc=""/>
+    <constraint exp="" field="parent_autoobjectcatitem" desc=""/>
+    <constraint exp="" field="parent_pubchannelitem" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <editform tolerant="1"></editform>
@@ -409,57 +408,70 @@
   <editforminitfilepath></editforminitfilepath>
   <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
-QGIS-Formulare können eine Python-Funktion haben,, die aufgerufen wird, wenn sich das Formular öffnet
+QGIS forms can have a Python function that is called when the form is
+opened.
 
-Diese Funktion kann verwendet werden um dem Formular Extralogik hinzuzufügen.
+Use this function to add extra logic to your forms.
 
-Der Name der Funktion wird im Feld "Python Init-Function" angegeben
-Ein Beispiel folgt:
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
 """
 from qgis.PyQt.QtWidgets import QWidget
 
 def my_form_open(dialog, layer, feature):
-	geom = feature.geometry()
-	control = dialog.findChild(QWidget, "MyLineEdit")
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorHtmlElement showLabel="0" name="Dummy to create empty form"></attributeEditorHtmlElement>
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="English" columnCount="1" groupBox="1" showLabel="1">
+      <attributeEditorField name="aname_en" index="10" showLabel="0"/>
+      <attributeEditorField name="adescription_en" index="16" showLabel="0"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="French" columnCount="1" groupBox="1" showLabel="1">
+      <attributeEditorField name="aname_fr" index="7" showLabel="0"/>
+      <attributeEditorField name="adescription_fr" index="13" showLabel="0"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="German" columnCount="1" groupBox="1" showLabel="1">
+      <attributeEditorField name="aname_de" index="6" showLabel="0"/>
+      <attributeEditorField name="adescription_de" index="12" showLabel="0"/>
+    </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field editable="1" name="T_Id"/>
-    <field editable="1" name="T_Ili_Tid"/>
-    <field editable="1" name="T_basket"/>
-    <field editable="1" name="acode"/>
-    <field editable="1" name="adescription"/>
-    <field editable="1" name="adescription_de"/>
-    <field editable="1" name="adescription_en"/>
-    <field editable="1" name="adescription_fr"/>
-    <field editable="1" name="adescription_it"/>
-    <field editable="1" name="adescription_rm"/>
-    <field editable="1" name="aname"/>
-    <field editable="1" name="aname_de"/>
-    <field editable="1" name="aname_en"/>
-    <field editable="1" name="aname_fr"/>
-    <field editable="1" name="aname_it"/>
-    <field editable="1" name="aname_rm"/>
-    <field editable="1" name="geolcode"/>
-    <field editable="1" name="issuperitem"/>
-    <field editable="1" name="isuseable"/>
-    <field editable="1" name="parent_assetformatitem"/>
-    <field editable="1" name="parent_assetkinditem"/>
-    <field editable="1" name="parent_autocatlabelitem"/>
-    <field editable="1" name="parent_autoobjectcatitem"/>
-    <field editable="1" name="parent_contactkinditem"/>
-    <field editable="1" name="parent_geomqualityitem"/>
-    <field editable="1" name="parent_languageitem"/>
-    <field editable="1" name="parent_legaldocitem"/>
-    <field editable="1" name="parent_mancatlabelitem"/>
-    <field editable="1" name="parent_natrelitem"/>
-    <field editable="1" name="parent_pubchannelitem"/>
-    <field editable="1" name="parent_statusassetuseitem"/>
-    <field editable="1" name="parent_statusworkitem"/>
+    <field name="T_Id" editable="1"/>
+    <field name="T_Ili_Tid" editable="1"/>
+    <field name="T_basket" editable="1"/>
+    <field name="acode" editable="1"/>
+    <field name="adescription" editable="1"/>
+    <field name="adescription_de" editable="0"/>
+    <field name="adescription_en" editable="0"/>
+    <field name="adescription_fr" editable="0"/>
+    <field name="adescription_it" editable="1"/>
+    <field name="adescription_rm" editable="1"/>
+    <field name="aname" editable="1"/>
+    <field name="aname_de" editable="0"/>
+    <field name="aname_en" editable="1"/>
+    <field name="aname_fr" editable="0"/>
+    <field name="aname_it" editable="1"/>
+    <field name="aname_rm" editable="1"/>
+    <field name="geolcode" editable="1"/>
+    <field name="issuperitem" editable="1"/>
+    <field name="isuseable" editable="1"/>
+    <field name="parent_assetformatitem" editable="1"/>
+    <field name="parent_assetkinditem" editable="1"/>
+    <field name="parent_autocatlabelitem" editable="1"/>
+    <field name="parent_autoobjectcatitem" editable="1"/>
+    <field name="parent_contactkinditem" editable="1"/>
+    <field name="parent_geomqualityitem" editable="1"/>
+    <field name="parent_languageitem" editable="1"/>
+    <field name="parent_legaldocitem" editable="1"/>
+    <field name="parent_mancatlabelitem" editable="1"/>
+    <field name="parent_natrelitem" editable="1"/>
+    <field name="parent_pubchannelitem" editable="1"/>
+    <field name="parent_statusassetuseitem" editable="1"/>
+    <field name="parent_statusworkitem" editable="1"/>
   </editable>
   <labelOnTop>
     <field name="T_Id" labelOnTop="0"/>
@@ -496,40 +508,41 @@ def my_form_open(dialog, layer, feature):
     <field name="parent_statusworkitem" labelOnTop="0"/>
   </labelOnTop>
   <reuseLastValue>
-    <field reuseLastValue="0" name="T_Id"/>
-    <field reuseLastValue="0" name="T_Ili_Tid"/>
-    <field reuseLastValue="0" name="T_basket"/>
-    <field reuseLastValue="0" name="acode"/>
-    <field reuseLastValue="0" name="adescription"/>
-    <field reuseLastValue="0" name="adescription_de"/>
-    <field reuseLastValue="0" name="adescription_en"/>
-    <field reuseLastValue="0" name="adescription_fr"/>
-    <field reuseLastValue="0" name="adescription_it"/>
-    <field reuseLastValue="0" name="adescription_rm"/>
-    <field reuseLastValue="0" name="aname"/>
-    <field reuseLastValue="0" name="aname_de"/>
-    <field reuseLastValue="0" name="aname_en"/>
-    <field reuseLastValue="0" name="aname_fr"/>
-    <field reuseLastValue="0" name="aname_it"/>
-    <field reuseLastValue="0" name="aname_rm"/>
-    <field reuseLastValue="0" name="geolcode"/>
-    <field reuseLastValue="0" name="issuperitem"/>
-    <field reuseLastValue="0" name="isuseable"/>
-    <field reuseLastValue="0" name="parent_assetformatitem"/>
-    <field reuseLastValue="0" name="parent_assetkinditem"/>
-    <field reuseLastValue="0" name="parent_autocatlabelitem"/>
-    <field reuseLastValue="0" name="parent_autoobjectcatitem"/>
-    <field reuseLastValue="0" name="parent_contactkinditem"/>
-    <field reuseLastValue="0" name="parent_geomqualityitem"/>
-    <field reuseLastValue="0" name="parent_languageitem"/>
-    <field reuseLastValue="0" name="parent_legaldocitem"/>
-    <field reuseLastValue="0" name="parent_mancatlabelitem"/>
-    <field reuseLastValue="0" name="parent_natrelitem"/>
-    <field reuseLastValue="0" name="parent_pubchannelitem"/>
-    <field reuseLastValue="0" name="parent_statusassetuseitem"/>
-    <field reuseLastValue="0" name="parent_statusworkitem"/>
+    <field name="T_Id" reuseLastValue="0"/>
+    <field name="T_Ili_Tid" reuseLastValue="0"/>
+    <field name="T_basket" reuseLastValue="0"/>
+    <field name="acode" reuseLastValue="0"/>
+    <field name="adescription" reuseLastValue="0"/>
+    <field name="adescription_de" reuseLastValue="0"/>
+    <field name="adescription_en" reuseLastValue="0"/>
+    <field name="adescription_fr" reuseLastValue="0"/>
+    <field name="adescription_it" reuseLastValue="0"/>
+    <field name="adescription_rm" reuseLastValue="0"/>
+    <field name="aname" reuseLastValue="0"/>
+    <field name="aname_de" reuseLastValue="0"/>
+    <field name="aname_en" reuseLastValue="0"/>
+    <field name="aname_fr" reuseLastValue="0"/>
+    <field name="aname_it" reuseLastValue="0"/>
+    <field name="aname_rm" reuseLastValue="0"/>
+    <field name="geolcode" reuseLastValue="0"/>
+    <field name="issuperitem" reuseLastValue="0"/>
+    <field name="isuseable" reuseLastValue="0"/>
+    <field name="parent_assetformatitem" reuseLastValue="0"/>
+    <field name="parent_assetkinditem" reuseLastValue="0"/>
+    <field name="parent_autocatlabelitem" reuseLastValue="0"/>
+    <field name="parent_autoobjectcatitem" reuseLastValue="0"/>
+    <field name="parent_contactkinditem" reuseLastValue="0"/>
+    <field name="parent_geomqualityitem" reuseLastValue="0"/>
+    <field name="parent_languageitem" reuseLastValue="0"/>
+    <field name="parent_legaldocitem" reuseLastValue="0"/>
+    <field name="parent_mancatlabelitem" reuseLastValue="0"/>
+    <field name="parent_natrelitem" reuseLastValue="0"/>
+    <field name="parent_pubchannelitem" reuseLastValue="0"/>
+    <field name="parent_statusassetuseitem" reuseLastValue="0"/>
+    <field name="parent_statusworkitem" reuseLastValue="0"/>
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>
+  <previewExpression>"aname_de"</previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/layerstyle/contact.qml
+++ b/lg_geolassets_v2/layerstyle/contact.qml
@@ -1,133 +1,127 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="LayerConfiguration|Fields|Forms" version="3.22.7-Białowieża" readOnly="0">
-  <flags>
-    <Identifiable>1</Identifiable>
-    <Removable>1</Removable>
-    <Searchable>1</Searchable>
-    <Private>0</Private>
-  </flags>
+<qgis styleCategories="Fields|Forms" version="3.24.3-Tisler">
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id">
+    <field name="T_Id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_basket">
+    <field name="T_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" value="false" type="bool"/>
-            <Option name="AllowNULL" value="false" type="bool"/>
-            <Option name="ChainFilters" value="false" type="bool"/>
-            <Option name="FilterExpression" value="&quot;topic&quot; = 'LG_GeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="ChainFilters" type="bool" value="false"/>
+            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; = 'LG_GeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
             <Option name="FilterFields" type="invalid"/>
-            <Option name="MapIdentification" value="false" type="bool"/>
-            <Option name="OrderByValue" value="true" type="bool"/>
-            <Option name="ReadOnly" value="false" type="bool"/>
-            <Option name="ReferencedLayerDataSource" value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" type="QString"/>
-            <Option name="ReferencedLayerId" value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" type="QString"/>
-            <Option name="ReferencedLayerName" value="T_ILI2DB_BASKET" type="QString"/>
-            <Option name="ReferencedLayerProviderKey" value="ogr" type="QString"/>
-            <Option name="Relation" value="lg_geolssts_v2geolassets_contact_T_basket_T_ILI2DB_BASKET_T_Id" type="QString"/>
-            <Option name="ShowForm" value="false" type="bool"/>
-            <Option name="ShowOpenFormButton" value="false" type="bool"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c"/>
+            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="lg_geolssts_v2geolassets_contact_T_basket_T_ILI2DB_BASKET_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_Ili_Tid">
+    <field name="T_Ili_Tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="idzad">
+    <field name="idzad" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="akind">
+    <field name="akind" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" value="false" type="bool"/>
-            <Option name="AllowNULL" value="true" type="bool"/>
-            <Option name="ChainFilters" value="false" type="bool"/>
-            <Option name="FilterExpression" value="" type="QString"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="ChainFilters" type="bool" value="false"/>
+            <Option name="FilterExpression" type="QString" value=""/>
             <Option name="FilterFields" type="invalid"/>
-            <Option name="MapIdentification" value="false" type="bool"/>
-            <Option name="OrderByValue" value="true" type="bool"/>
-            <Option name="ReadOnly" value="false" type="bool"/>
-            <Option name="ReferencedLayerDataSource" value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=contactkinditem" type="QString"/>
-            <Option name="ReferencedLayerId" value="ContactKindItem_bedb9ab1_e3c6_4fd4_81df_5e51153c34c8" type="QString"/>
-            <Option name="ReferencedLayerName" value="ContactKindItem" type="QString"/>
-            <Option name="ReferencedLayerProviderKey" value="ogr" type="QString"/>
-            <Option name="Relation" value="lg_geolssts_v2geolassets_contact_akind_contactkinditem_T_Id" type="QString"/>
-            <Option name="ShowForm" value="false" type="bool"/>
-            <Option name="ShowOpenFormButton" value="false" type="bool"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=contactkinditem"/>
+            <Option name="ReferencedLayerId" type="QString" value="ContactKindItem_bedb9ab1_e3c6_4fd4_81df_5e51153c34c8"/>
+            <Option name="ReferencedLayerName" type="QString" value="ContactKindItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="lg_geolssts_v2geolassets_contact_akind_contactkinditem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="aname">
+    <field name="aname" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="telefon">
+    <field name="telefon" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="email">
+    <field name="email" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="website">
+    <field name="website" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" value="false" type="bool"/>
-            <Option name="UseHtml" value="false" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="T_Id" name="" index="0"/>
-    <alias field="T_basket" name="" index="1"/>
-    <alias field="T_Ili_Tid" name="" index="2"/>
-    <alias field="idzad" name="IDZAD" index="3"/>
-    <alias field="akind" name="Art" index="4"/>
-    <alias field="aname" name="Name" index="5"/>
-    <alias field="telefon" name="Telefon" index="6"/>
-    <alias field="email" name="Email (&quot;mailto:name@domain.ch&quot;)" index="7"/>
-    <alias field="website" name="Website (&quot;http://www.domain.ch&quot;)" index="8"/>
+    <alias name="" field="T_Id" index="0"/>
+    <alias name="" field="T_basket" index="1"/>
+    <alias name="" field="T_Ili_Tid" index="2"/>
+    <alias name="IDZAD" field="idzad" index="3"/>
+    <alias name="Art" field="akind" index="4"/>
+    <alias name="Name" field="aname" index="5"/>
+    <alias name="Telefon" field="telefon" index="6"/>
+    <alias name="Email (&quot;mailto:name@domain.ch&quot;)" field="email" index="7"/>
+    <alias name="Website (&quot;http://www.domain.ch&quot;)" field="website" index="8"/>
   </aliases>
   <defaults>
     <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
@@ -141,26 +135,26 @@
     <default field="website" expression="" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint field="T_Id" unique_strength="1" notnull_strength="1" constraints="3" exp_strength="0"/>
-    <constraint field="T_basket" unique_strength="0" notnull_strength="1" constraints="1" exp_strength="0"/>
-    <constraint field="T_Ili_Tid" unique_strength="0" notnull_strength="0" constraints="0" exp_strength="0"/>
-    <constraint field="idzad" unique_strength="0" notnull_strength="0" constraints="0" exp_strength="0"/>
-    <constraint field="akind" unique_strength="0" notnull_strength="1" constraints="1" exp_strength="0"/>
-    <constraint field="aname" unique_strength="0" notnull_strength="1" constraints="1" exp_strength="0"/>
-    <constraint field="telefon" unique_strength="0" notnull_strength="0" constraints="0" exp_strength="0"/>
-    <constraint field="email" unique_strength="0" notnull_strength="0" constraints="0" exp_strength="0"/>
-    <constraint field="website" unique_strength="0" notnull_strength="0" constraints="0" exp_strength="0"/>
+    <constraint constraints="3" field="T_Id" unique_strength="1" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="1" field="T_basket" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="T_Ili_Tid" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="idzad" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="1" field="akind" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="1" field="aname" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="telefon" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="email" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="website" unique_strength="0" exp_strength="0" notnull_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="T_Id" exp="" desc=""/>
-    <constraint field="T_basket" exp="" desc=""/>
-    <constraint field="T_Ili_Tid" exp="" desc=""/>
-    <constraint field="idzad" exp="" desc=""/>
-    <constraint field="akind" exp="" desc=""/>
-    <constraint field="aname" exp="" desc=""/>
-    <constraint field="telefon" exp="" desc=""/>
-    <constraint field="email" exp="" desc=""/>
-    <constraint field="website" exp="" desc=""/>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="T_Ili_Tid" desc=""/>
+    <constraint exp="" field="idzad" desc=""/>
+    <constraint exp="" field="akind" desc=""/>
+    <constraint exp="" field="aname" desc=""/>
+    <constraint exp="" field="telefon" desc=""/>
+    <constraint exp="" field="email" desc=""/>
+    <constraint exp="" field="website" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <editform tolerant="1"></editform>
@@ -185,19 +179,20 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer showLabel="1" name="Allgemein" visibilityExpressionEnabled="0" columnCount="2" groupBox="1" visibilityExpression="">
-      <attributeEditorField showLabel="1" name="aname" index="5"/>
-      <attributeEditorField showLabel="1" name="idzad" index="3"/>
-      <attributeEditorField showLabel="1" name="akind" index="4"/>
-      <attributeEditorField showLabel="1" name="email" index="7"/>
-      <attributeEditorField showLabel="1" name="telefon" index="6"/>
-      <attributeEditorField showLabel="1" name="website" index="8"/>
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Allgemein *" columnCount="2" groupBox="0" showLabel="1">
+      <attributeEditorField name="aname" index="5" showLabel="1"/>
+      <attributeEditorField name="idzad" index="3" showLabel="1"/>
+      <attributeEditorField name="akind" index="4" showLabel="1"/>
+      <attributeEditorField name="email" index="7" showLabel="1"/>
+      <attributeEditorField name="telefon" index="6" showLabel="1"/>
+      <attributeEditorField name="website" index="8" showLabel="1"/>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" name="Adresse (maximal ein Eintrag)" visibilityExpressionEnabled="0" columnCount="1" groupBox="1" visibilityExpression="">
-      <attributeEditorRelation showLabel="0" forceSuppressFormPopup="0" relationWidgetTypeId="relation_editor" relation="address_lg_glssts_vssts_cntact_address_lg_geolssts_v2geolassets_contact_T_Id" name="address_lg_glssts_vssts_cntact_address_lg_geolssts_v2geolassets_contact_T_Id" label="" nmRelationId="">
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Adresse" columnCount="1" groupBox="0" showLabel="1">
+      <attributeEditorRelation forceSuppressFormPopup="0" name="address_lg_glssts_vssts_cntact_address_lg_geolssts_v2geolassets_contact_T_Id" label="" relationWidgetTypeId="linking_relation_editor" nmRelationId="one_to_one" showLabel="0" relation="address_lg_glssts_vssts_cntact_address_lg_geolssts_v2geolassets_contact_T_Id">
         <editor_configuration type="Map">
-          <Option name="buttons" value="AddChildFeature|DeleteChildFeature" type="QString"/>
-          <Option name="show_first_feature" value="true" type="bool"/>
+          <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature"/>
+          <Option name="one_to_one" type="bool" value="true"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
@@ -239,29 +234,28 @@ def my_form_open(dialog, layer, feature):
   <widgets>
     <widget name="address_lg_glssts_vssts_cntact_address_lg_geolssts_v2geolassets_contact_T_Id">
       <config type="Map">
-        <Option name="force-suppress-popup" value="false" type="bool"/>
-        <Option name="nm-rel" value="" type="QString"/>
+        <Option name="force-suppress-popup" type="bool" value="false"/>
+        <Option name="nm-rel" type="QString" value=""/>
       </config>
     </widget>
     <widget name="assetitem_contact_author_author_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id">
       <config type="Map">
-        <Option name="force-suppress-popup" value="false" type="bool"/>
+        <Option name="force-suppress-popup" type="bool" value="false"/>
         <Option name="nm-rel" type="invalid"/>
       </config>
     </widget>
     <widget name="assetitem_contact_initiator_initiator_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id">
       <config type="Map">
-        <Option name="force-suppress-popup" value="false" type="bool"/>
+        <Option name="force-suppress-popup" type="bool" value="false"/>
         <Option name="nm-rel" type="invalid"/>
       </config>
     </widget>
     <widget name="assetitem_contact_supplier_supplier_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id">
       <config type="Map">
-        <Option name="force-suppress-popup" value="false" type="bool"/>
+        <Option name="force-suppress-popup" type="bool" value="false"/>
         <Option name="nm-rel" type="invalid"/>
       </config>
     </widget>
   </widgets>
-  <previewExpression>"aname"</previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/layerstyle/mancatlabelitem.qml
+++ b/lg_geolassets_v2/layerstyle/mancatlabelitem.qml
@@ -1,286 +1,263 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="Fields|Forms" version="3.25.0-Master">
+<qgis readOnly="1" styleCategories="LayerConfiguration|Fields|Forms" version="3.24.3-Tisler">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id">
+    <field name="T_Id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
-          </Option>
+          <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_basket">
+    <field name="T_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="&quot;topic&quot; = 'GeolAssetsCatalogues_V2.Catalogues' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" type="QString" name="ReferencedLayerId"/>
-            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="mancatlabelitem_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; = 'GeolAssetsCatalogues_V2.Catalogues' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="Relation" type="QString" value="assetkinditem_T_basket_T_ILI2DB_BASKET_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_Ili_Tid">
+    <field name="T_Ili_Tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="acode">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="geolcode">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname_de">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname_fr">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname_rm">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname_it">
+    <field name="acode" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="aname_en">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="adescription">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="adescription_de">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="adescription_fr">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="adescription_rm">
+    <field name="geolcode" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription_it">
+    <field name="aname" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription_en">
+    <field name="aname_de" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="aname_fr" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="aname_rm" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="aname_it" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="aname_en" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="adescription" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="issuperitem">
+    <field name="adescription_de" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="adescription_fr" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="adescription_rm" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="adescription_it" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="adescription_en" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="issuperitem" configurationFlags="None">
       <editWidget type="CheckBox">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="isuseable">
+    <field name="isuseable" configurationFlags="None">
       <editWidget type="CheckBox">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_statusworkitem">
+    <field name="parent_statusworkitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_natrelitem">
+    <field name="parent_assetkinditem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_languageitem">
-      <editWidget type="RelationReference">
-        <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="false" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="false" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_4/lg_geolAssets_v2_data.gpkg|layername=languageitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="LanguageItem_cd8d7272_96fc_46df_885d_993bcb12310c" type="QString" name="ReferencedLayerId"/>
-            <Option value="LanguageItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="mancatlabelitem_parent_languageitem_languageitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="true" type="bool" name="ShowOpenFormButton"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="parent_legaldocitem">
+    <field name="parent_languageitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_assetkinditem">
+    <field name="parent_natrelitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_statusassetuseitem">
+    <field name="parent_mancatlabelitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_autoobjectcatitem">
+    <field name="parent_autocatlabelitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_contactkinditem">
+    <field name="parent_contactkinditem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_assetformatitem">
+    <field name="parent_assetformatitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_mancatlabelitem">
+    <field name="parent_statusassetuseitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_autocatlabelitem">
+    <field name="parent_legaldocitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_pubchannelitem">
+    <field name="parent_geomqualityitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_geomqualityitem">
+    <field name="parent_autoobjectcatitem" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="parent_pubchannelitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
@@ -289,38 +266,38 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="T_Id" index="0" name=""/>
-    <alias field="T_basket" index="1" name=""/>
-    <alias field="T_Ili_Tid" index="2" name=""/>
-    <alias field="acode" index="3" name="Code"/>
-    <alias field="geolcode" index="4" name="GeolCode"/>
-    <alias field="aname" index="5" name="Name"/>
-    <alias field="aname_de" index="6" name=""/>
-    <alias field="aname_fr" index="7" name=""/>
-    <alias field="aname_rm" index="8" name=""/>
-    <alias field="aname_it" index="9" name=""/>
-    <alias field="aname_en" index="10" name=""/>
-    <alias field="adescription" index="11" name="Description"/>
-    <alias field="adescription_de" index="12" name=""/>
-    <alias field="adescription_fr" index="13" name=""/>
-    <alias field="adescription_rm" index="14" name=""/>
-    <alias field="adescription_it" index="15" name=""/>
-    <alias field="adescription_en" index="16" name=""/>
-    <alias field="issuperitem" index="17" name="IsSuperItem"/>
-    <alias field="isuseable" index="18" name="IsUseable"/>
-    <alias field="parent_statusworkitem" index="19" name="Parent"/>
-    <alias field="parent_natrelitem" index="20" name="Parent"/>
-    <alias field="parent_languageitem" index="21" name="Parent"/>
-    <alias field="parent_legaldocitem" index="22" name="Parent"/>
-    <alias field="parent_assetkinditem" index="23" name="Parent"/>
-    <alias field="parent_statusassetuseitem" index="24" name="Parent"/>
-    <alias field="parent_autoobjectcatitem" index="25" name="Parent"/>
-    <alias field="parent_contactkinditem" index="26" name="Parent"/>
-    <alias field="parent_assetformatitem" index="27" name="Parent"/>
-    <alias field="parent_mancatlabelitem" index="28" name="Parent"/>
-    <alias field="parent_autocatlabelitem" index="29" name="Parent"/>
-    <alias field="parent_pubchannelitem" index="30" name="Parent"/>
-    <alias field="parent_geomqualityitem" index="31" name="Parent"/>
+    <alias name="" field="T_Id" index="0"/>
+    <alias name="" field="T_basket" index="1"/>
+    <alias name="" field="T_Ili_Tid" index="2"/>
+    <alias name="Code" field="acode" index="3"/>
+    <alias name="GeolCode" field="geolcode" index="4"/>
+    <alias name="Name" field="aname" index="5"/>
+    <alias name="" field="aname_de" index="6"/>
+    <alias name="" field="aname_fr" index="7"/>
+    <alias name="" field="aname_rm" index="8"/>
+    <alias name="" field="aname_it" index="9"/>
+    <alias name="" field="aname_en" index="10"/>
+    <alias name="Description" field="adescription" index="11"/>
+    <alias name="" field="adescription_de" index="12"/>
+    <alias name="" field="adescription_fr" index="13"/>
+    <alias name="" field="adescription_rm" index="14"/>
+    <alias name="" field="adescription_it" index="15"/>
+    <alias name="" field="adescription_en" index="16"/>
+    <alias name="IsSuperItem" field="issuperitem" index="17"/>
+    <alias name="IsUseable" field="isuseable" index="18"/>
+    <alias name="Parent" field="parent_statusworkitem" index="19"/>
+    <alias name="Parent" field="parent_assetkinditem" index="20"/>
+    <alias name="Parent" field="parent_languageitem" index="21"/>
+    <alias name="Parent" field="parent_natrelitem" index="22"/>
+    <alias name="Parent" field="parent_mancatlabelitem" index="23"/>
+    <alias name="Parent" field="parent_autocatlabelitem" index="24"/>
+    <alias name="Parent" field="parent_contactkinditem" index="25"/>
+    <alias name="Parent" field="parent_assetformatitem" index="26"/>
+    <alias name="Parent" field="parent_statusassetuseitem" index="27"/>
+    <alias name="Parent" field="parent_legaldocitem" index="28"/>
+    <alias name="Parent" field="parent_geomqualityitem" index="29"/>
+    <alias name="Parent" field="parent_autoobjectcatitem" index="30"/>
+    <alias name="Parent" field="parent_pubchannelitem" index="31"/>
   </aliases>
   <defaults>
     <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
@@ -343,86 +320,86 @@
     <default field="issuperitem" expression="" applyOnUpdate="0"/>
     <default field="isuseable" expression="" applyOnUpdate="0"/>
     <default field="parent_statusworkitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_natrelitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_languageitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_legaldocitem" expression="" applyOnUpdate="0"/>
     <default field="parent_assetkinditem" expression="" applyOnUpdate="0"/>
-    <default field="parent_statusassetuseitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_autoobjectcatitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_contactkinditem" expression="" applyOnUpdate="0"/>
-    <default field="parent_assetformatitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_languageitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_natrelitem" expression="" applyOnUpdate="0"/>
     <default field="parent_mancatlabelitem" expression="" applyOnUpdate="0"/>
     <default field="parent_autocatlabelitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_pubchannelitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_contactkinditem" expression="" applyOnUpdate="0"/>
+    <default field="parent_assetformatitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_statusassetuseitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_legaldocitem" expression="" applyOnUpdate="0"/>
     <default field="parent_geomqualityitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_autoobjectcatitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_pubchannelitem" expression="" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" notnull_strength="1" field="T_Id" exp_strength="0" constraints="3"/>
-    <constraint unique_strength="0" notnull_strength="1" field="T_basket" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="T_Ili_Tid" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="1" field="acode" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="geolcode" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname_de" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname_fr" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname_rm" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname_it" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname_en" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription_de" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription_fr" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription_rm" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription_it" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription_en" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="1" field="issuperitem" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="1" field="isuseable" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_statusworkitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_natrelitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_languageitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_legaldocitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_assetkinditem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_statusassetuseitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_autoobjectcatitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_contactkinditem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_assetformatitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_mancatlabelitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_autocatlabelitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_pubchannelitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_geomqualityitem" exp_strength="0" constraints="0"/>
+    <constraint constraints="3" field="T_Id" unique_strength="1" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="1" field="T_basket" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="T_Ili_Tid" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="1" field="acode" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="geolcode" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_de" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_fr" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_rm" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_it" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_en" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_de" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_fr" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_rm" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_it" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_en" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="1" field="issuperitem" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="1" field="isuseable" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="parent_statusworkitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_assetkinditem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_languageitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_natrelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_mancatlabelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_autocatlabelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_contactkinditem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_assetformatitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_statusassetuseitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_legaldocitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_geomqualityitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_autoobjectcatitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_pubchannelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="T_Id" desc="" exp=""/>
-    <constraint field="T_basket" desc="" exp=""/>
-    <constraint field="T_Ili_Tid" desc="" exp=""/>
-    <constraint field="acode" desc="" exp=""/>
-    <constraint field="geolcode" desc="" exp=""/>
-    <constraint field="aname" desc="" exp=""/>
-    <constraint field="aname_de" desc="" exp=""/>
-    <constraint field="aname_fr" desc="" exp=""/>
-    <constraint field="aname_rm" desc="" exp=""/>
-    <constraint field="aname_it" desc="" exp=""/>
-    <constraint field="aname_en" desc="" exp=""/>
-    <constraint field="adescription" desc="" exp=""/>
-    <constraint field="adescription_de" desc="" exp=""/>
-    <constraint field="adescription_fr" desc="" exp=""/>
-    <constraint field="adescription_rm" desc="" exp=""/>
-    <constraint field="adescription_it" desc="" exp=""/>
-    <constraint field="adescription_en" desc="" exp=""/>
-    <constraint field="issuperitem" desc="" exp=""/>
-    <constraint field="isuseable" desc="" exp=""/>
-    <constraint field="parent_statusworkitem" desc="" exp=""/>
-    <constraint field="parent_natrelitem" desc="" exp=""/>
-    <constraint field="parent_languageitem" desc="" exp=""/>
-    <constraint field="parent_legaldocitem" desc="" exp=""/>
-    <constraint field="parent_assetkinditem" desc="" exp=""/>
-    <constraint field="parent_statusassetuseitem" desc="" exp=""/>
-    <constraint field="parent_autoobjectcatitem" desc="" exp=""/>
-    <constraint field="parent_contactkinditem" desc="" exp=""/>
-    <constraint field="parent_assetformatitem" desc="" exp=""/>
-    <constraint field="parent_mancatlabelitem" desc="" exp=""/>
-    <constraint field="parent_autocatlabelitem" desc="" exp=""/>
-    <constraint field="parent_pubchannelitem" desc="" exp=""/>
-    <constraint field="parent_geomqualityitem" desc="" exp=""/>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="T_Ili_Tid" desc=""/>
+    <constraint exp="" field="acode" desc=""/>
+    <constraint exp="" field="geolcode" desc=""/>
+    <constraint exp="" field="aname" desc=""/>
+    <constraint exp="" field="aname_de" desc=""/>
+    <constraint exp="" field="aname_fr" desc=""/>
+    <constraint exp="" field="aname_rm" desc=""/>
+    <constraint exp="" field="aname_it" desc=""/>
+    <constraint exp="" field="aname_en" desc=""/>
+    <constraint exp="" field="adescription" desc=""/>
+    <constraint exp="" field="adescription_de" desc=""/>
+    <constraint exp="" field="adescription_fr" desc=""/>
+    <constraint exp="" field="adescription_rm" desc=""/>
+    <constraint exp="" field="adescription_it" desc=""/>
+    <constraint exp="" field="adescription_en" desc=""/>
+    <constraint exp="" field="issuperitem" desc=""/>
+    <constraint exp="" field="isuseable" desc=""/>
+    <constraint exp="" field="parent_statusworkitem" desc=""/>
+    <constraint exp="" field="parent_assetkinditem" desc=""/>
+    <constraint exp="" field="parent_languageitem" desc=""/>
+    <constraint exp="" field="parent_natrelitem" desc=""/>
+    <constraint exp="" field="parent_mancatlabelitem" desc=""/>
+    <constraint exp="" field="parent_autocatlabelitem" desc=""/>
+    <constraint exp="" field="parent_contactkinditem" desc=""/>
+    <constraint exp="" field="parent_assetformatitem" desc=""/>
+    <constraint exp="" field="parent_statusassetuseitem" desc=""/>
+    <constraint exp="" field="parent_legaldocitem" desc=""/>
+    <constraint exp="" field="parent_geomqualityitem" desc=""/>
+    <constraint exp="" field="parent_autoobjectcatitem" desc=""/>
+    <constraint exp="" field="parent_pubchannelitem" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <editform tolerant="1"></editform>
@@ -431,23 +408,36 @@
   <editforminitfilepath></editforminitfilepath>
   <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
-QGIS-Formulare können eine Python-Funktion haben,, die aufgerufen wird, wenn sich das Formular öffnet
+QGIS forms can have a Python function that is called when the form is
+opened.
 
-Diese Funktion kann verwendet werden um dem Formular Extralogik hinzuzufügen.
+Use this function to add extra logic to your forms.
 
-Der Name der Funktion wird im Feld "Python Init-Function" angegeben
-Ein Beispiel folgt:
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
 """
 from qgis.PyQt.QtWidgets import QWidget
 
 def my_form_open(dialog, layer, feature):
-	geom = feature.geometry()
-	control = dialog.findChild(QWidget, "MyLineEdit")
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorHtmlElement showLabel="0" name="Dummy to create empty form"></attributeEditorHtmlElement>
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="English" columnCount="1" groupBox="1" showLabel="1">
+      <attributeEditorField name="aname_en" index="10" showLabel="0"/>
+      <attributeEditorField name="adescription_en" index="16" showLabel="0"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="French" columnCount="1" groupBox="1" showLabel="1">
+      <attributeEditorField name="aname_fr" index="7" showLabel="0"/>
+      <attributeEditorField name="adescription_fr" index="13" showLabel="0"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="German" columnCount="1" groupBox="1" showLabel="1">
+      <attributeEditorField name="aname_de" index="6" showLabel="0"/>
+      <attributeEditorField name="adescription_de" index="12" showLabel="0"/>
+    </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
     <field name="T_Id" editable="1"/>
@@ -455,15 +445,15 @@ def my_form_open(dialog, layer, feature):
     <field name="T_basket" editable="1"/>
     <field name="acode" editable="1"/>
     <field name="adescription" editable="1"/>
-    <field name="adescription_de" editable="1"/>
-    <field name="adescription_en" editable="1"/>
-    <field name="adescription_fr" editable="1"/>
+    <field name="adescription_de" editable="0"/>
+    <field name="adescription_en" editable="0"/>
+    <field name="adescription_fr" editable="0"/>
     <field name="adescription_it" editable="1"/>
     <field name="adescription_rm" editable="1"/>
     <field name="aname" editable="1"/>
-    <field name="aname_de" editable="1"/>
+    <field name="aname_de" editable="0"/>
     <field name="aname_en" editable="1"/>
-    <field name="aname_fr" editable="1"/>
+    <field name="aname_fr" editable="0"/>
     <field name="aname_it" editable="1"/>
     <field name="aname_rm" editable="1"/>
     <field name="geolcode" editable="1"/>
@@ -484,74 +474,75 @@ def my_form_open(dialog, layer, feature):
     <field name="parent_statusworkitem" editable="1"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="T_Id"/>
-    <field labelOnTop="0" name="T_Ili_Tid"/>
-    <field labelOnTop="0" name="T_basket"/>
-    <field labelOnTop="0" name="acode"/>
-    <field labelOnTop="0" name="adescription"/>
-    <field labelOnTop="0" name="adescription_de"/>
-    <field labelOnTop="0" name="adescription_en"/>
-    <field labelOnTop="0" name="adescription_fr"/>
-    <field labelOnTop="0" name="adescription_it"/>
-    <field labelOnTop="0" name="adescription_rm"/>
-    <field labelOnTop="0" name="aname"/>
-    <field labelOnTop="0" name="aname_de"/>
-    <field labelOnTop="0" name="aname_en"/>
-    <field labelOnTop="0" name="aname_fr"/>
-    <field labelOnTop="0" name="aname_it"/>
-    <field labelOnTop="0" name="aname_rm"/>
-    <field labelOnTop="0" name="geolcode"/>
-    <field labelOnTop="0" name="issuperitem"/>
-    <field labelOnTop="0" name="isuseable"/>
-    <field labelOnTop="0" name="parent_assetformatitem"/>
-    <field labelOnTop="0" name="parent_assetkinditem"/>
-    <field labelOnTop="0" name="parent_autocatlabelitem"/>
-    <field labelOnTop="0" name="parent_autoobjectcatitem"/>
-    <field labelOnTop="0" name="parent_contactkinditem"/>
-    <field labelOnTop="0" name="parent_geomqualityitem"/>
-    <field labelOnTop="0" name="parent_languageitem"/>
-    <field labelOnTop="0" name="parent_legaldocitem"/>
-    <field labelOnTop="0" name="parent_mancatlabelitem"/>
-    <field labelOnTop="0" name="parent_natrelitem"/>
-    <field labelOnTop="0" name="parent_pubchannelitem"/>
-    <field labelOnTop="0" name="parent_statusassetuseitem"/>
-    <field labelOnTop="0" name="parent_statusworkitem"/>
+    <field name="T_Id" labelOnTop="0"/>
+    <field name="T_Ili_Tid" labelOnTop="0"/>
+    <field name="T_basket" labelOnTop="0"/>
+    <field name="acode" labelOnTop="0"/>
+    <field name="adescription" labelOnTop="0"/>
+    <field name="adescription_de" labelOnTop="0"/>
+    <field name="adescription_en" labelOnTop="0"/>
+    <field name="adescription_fr" labelOnTop="0"/>
+    <field name="adescription_it" labelOnTop="0"/>
+    <field name="adescription_rm" labelOnTop="0"/>
+    <field name="aname" labelOnTop="0"/>
+    <field name="aname_de" labelOnTop="0"/>
+    <field name="aname_en" labelOnTop="0"/>
+    <field name="aname_fr" labelOnTop="0"/>
+    <field name="aname_it" labelOnTop="0"/>
+    <field name="aname_rm" labelOnTop="0"/>
+    <field name="geolcode" labelOnTop="0"/>
+    <field name="issuperitem" labelOnTop="0"/>
+    <field name="isuseable" labelOnTop="0"/>
+    <field name="parent_assetformatitem" labelOnTop="0"/>
+    <field name="parent_assetkinditem" labelOnTop="0"/>
+    <field name="parent_autocatlabelitem" labelOnTop="0"/>
+    <field name="parent_autoobjectcatitem" labelOnTop="0"/>
+    <field name="parent_contactkinditem" labelOnTop="0"/>
+    <field name="parent_geomqualityitem" labelOnTop="0"/>
+    <field name="parent_languageitem" labelOnTop="0"/>
+    <field name="parent_legaldocitem" labelOnTop="0"/>
+    <field name="parent_mancatlabelitem" labelOnTop="0"/>
+    <field name="parent_natrelitem" labelOnTop="0"/>
+    <field name="parent_pubchannelitem" labelOnTop="0"/>
+    <field name="parent_statusassetuseitem" labelOnTop="0"/>
+    <field name="parent_statusworkitem" labelOnTop="0"/>
   </labelOnTop>
   <reuseLastValue>
-    <field reuseLastValue="0" name="T_Id"/>
-    <field reuseLastValue="0" name="T_Ili_Tid"/>
-    <field reuseLastValue="0" name="T_basket"/>
-    <field reuseLastValue="0" name="acode"/>
-    <field reuseLastValue="0" name="adescription"/>
-    <field reuseLastValue="0" name="adescription_de"/>
-    <field reuseLastValue="0" name="adescription_en"/>
-    <field reuseLastValue="0" name="adescription_fr"/>
-    <field reuseLastValue="0" name="adescription_it"/>
-    <field reuseLastValue="0" name="adescription_rm"/>
-    <field reuseLastValue="0" name="aname"/>
-    <field reuseLastValue="0" name="aname_de"/>
-    <field reuseLastValue="0" name="aname_en"/>
-    <field reuseLastValue="0" name="aname_fr"/>
-    <field reuseLastValue="0" name="aname_it"/>
-    <field reuseLastValue="0" name="aname_rm"/>
-    <field reuseLastValue="0" name="geolcode"/>
-    <field reuseLastValue="0" name="issuperitem"/>
-    <field reuseLastValue="0" name="isuseable"/>
-    <field reuseLastValue="0" name="parent_assetformatitem"/>
-    <field reuseLastValue="0" name="parent_assetkinditem"/>
-    <field reuseLastValue="0" name="parent_autocatlabelitem"/>
-    <field reuseLastValue="0" name="parent_autoobjectcatitem"/>
-    <field reuseLastValue="0" name="parent_contactkinditem"/>
-    <field reuseLastValue="0" name="parent_geomqualityitem"/>
-    <field reuseLastValue="0" name="parent_languageitem"/>
-    <field reuseLastValue="0" name="parent_legaldocitem"/>
-    <field reuseLastValue="0" name="parent_mancatlabelitem"/>
-    <field reuseLastValue="0" name="parent_natrelitem"/>
-    <field reuseLastValue="0" name="parent_pubchannelitem"/>
-    <field reuseLastValue="0" name="parent_statusassetuseitem"/>
-    <field reuseLastValue="0" name="parent_statusworkitem"/>
+    <field name="T_Id" reuseLastValue="0"/>
+    <field name="T_Ili_Tid" reuseLastValue="0"/>
+    <field name="T_basket" reuseLastValue="0"/>
+    <field name="acode" reuseLastValue="0"/>
+    <field name="adescription" reuseLastValue="0"/>
+    <field name="adescription_de" reuseLastValue="0"/>
+    <field name="adescription_en" reuseLastValue="0"/>
+    <field name="adescription_fr" reuseLastValue="0"/>
+    <field name="adescription_it" reuseLastValue="0"/>
+    <field name="adescription_rm" reuseLastValue="0"/>
+    <field name="aname" reuseLastValue="0"/>
+    <field name="aname_de" reuseLastValue="0"/>
+    <field name="aname_en" reuseLastValue="0"/>
+    <field name="aname_fr" reuseLastValue="0"/>
+    <field name="aname_it" reuseLastValue="0"/>
+    <field name="aname_rm" reuseLastValue="0"/>
+    <field name="geolcode" reuseLastValue="0"/>
+    <field name="issuperitem" reuseLastValue="0"/>
+    <field name="isuseable" reuseLastValue="0"/>
+    <field name="parent_assetformatitem" reuseLastValue="0"/>
+    <field name="parent_assetkinditem" reuseLastValue="0"/>
+    <field name="parent_autocatlabelitem" reuseLastValue="0"/>
+    <field name="parent_autoobjectcatitem" reuseLastValue="0"/>
+    <field name="parent_contactkinditem" reuseLastValue="0"/>
+    <field name="parent_geomqualityitem" reuseLastValue="0"/>
+    <field name="parent_languageitem" reuseLastValue="0"/>
+    <field name="parent_legaldocitem" reuseLastValue="0"/>
+    <field name="parent_mancatlabelitem" reuseLastValue="0"/>
+    <field name="parent_natrelitem" reuseLastValue="0"/>
+    <field name="parent_pubchannelitem" reuseLastValue="0"/>
+    <field name="parent_statusassetuseitem" reuseLastValue="0"/>
+    <field name="parent_statusworkitem" reuseLastValue="0"/>
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>
+  <previewExpression>"aname_de"</previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/layerstyle/natrelitem.qml
+++ b/lg_geolassets_v2/layerstyle/natrelitem.qml
@@ -1,280 +1,263 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="Fields|Forms" version="3.25.0-Master">
+<qgis readOnly="1" styleCategories="LayerConfiguration|Fields|Forms" version="3.24.3-Tisler">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id">
+    <field name="T_Id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
-          </Option>
+          <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_basket">
+    <field name="T_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="&quot;topic&quot; = 'LG_GeolAssetsCatalogues_V2.Catalogues' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" type="QString" name="ReferencedLayerId"/>
-            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="natrelitem_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; = 'GeolAssetsCatalogues_V2.Catalogues' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="Relation" type="QString" value="assetkinditem_T_basket_T_ILI2DB_BASKET_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_Ili_Tid">
+    <field name="T_Ili_Tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="acode">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="geolcode">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname">
+    <field name="acode" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="aname_de">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname_fr">
-      <editWidget type="TextEdit">
-        <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname_rm">
+    <field name="geolcode" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="aname_it">
+    <field name="aname" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="aname_en">
+    <field name="aname_de" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription">
+    <field name="aname_fr" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription_de">
+    <field name="aname_rm" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription_fr">
+    <field name="aname_it" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription_rm">
+    <field name="aname_en" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="adescription" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription_it">
+    <field name="adescription_de" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="adescription_fr" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="adescription_rm" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription_en">
+    <field name="adescription_it" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="issuperitem">
+    <field name="adescription_en" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="issuperitem" configurationFlags="None">
       <editWidget type="CheckBox">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="isuseable">
+    <field name="isuseable" configurationFlags="None">
       <editWidget type="CheckBox">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_statusworkitem">
+    <field name="parent_statusworkitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_natrelitem">
+    <field name="parent_assetkinditem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_languageitem">
-      <editWidget type="RelationReference">
-        <config>
-          <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="false" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="false" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=languageitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="LanguageItem_cd8d7272_96fc_46df_885d_993bcb12310c" type="QString" name="ReferencedLayerId"/>
-            <Option value="LanguageItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="natrelitem_parent_languageitem_languageitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="true" type="bool" name="ShowOpenFormButton"/>
-          </Option>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="parent_legaldocitem">
+    <field name="parent_languageitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_assetkinditem">
+    <field name="parent_natrelitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_statusassetuseitem">
+    <field name="parent_mancatlabelitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_autoobjectcatitem">
+    <field name="parent_autocatlabelitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_contactkinditem">
+    <field name="parent_contactkinditem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_assetformatitem">
+    <field name="parent_assetformatitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_mancatlabelitem">
+    <field name="parent_statusassetuseitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_autocatlabelitem">
+    <field name="parent_legaldocitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_pubchannelitem">
+    <field name="parent_geomqualityitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="parent_geomqualityitem">
+    <field name="parent_autoobjectcatitem" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="parent_pubchannelitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
@@ -283,38 +266,38 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="T_Id" index="0" name=""/>
-    <alias field="T_basket" index="1" name=""/>
-    <alias field="T_Ili_Tid" index="2" name=""/>
-    <alias field="acode" index="3" name="Code"/>
-    <alias field="geolcode" index="4" name="GeolCode"/>
-    <alias field="aname" index="5" name="Name"/>
-    <alias field="aname_de" index="6" name=""/>
-    <alias field="aname_fr" index="7" name=""/>
-    <alias field="aname_rm" index="8" name=""/>
-    <alias field="aname_it" index="9" name=""/>
-    <alias field="aname_en" index="10" name=""/>
-    <alias field="adescription" index="11" name="Description"/>
-    <alias field="adescription_de" index="12" name=""/>
-    <alias field="adescription_fr" index="13" name=""/>
-    <alias field="adescription_rm" index="14" name=""/>
-    <alias field="adescription_it" index="15" name=""/>
-    <alias field="adescription_en" index="16" name=""/>
-    <alias field="issuperitem" index="17" name="IsSuperItem"/>
-    <alias field="isuseable" index="18" name="IsUseable"/>
-    <alias field="parent_statusworkitem" index="19" name="Parent"/>
-    <alias field="parent_natrelitem" index="20" name="Parent"/>
-    <alias field="parent_languageitem" index="21" name="Parent"/>
-    <alias field="parent_legaldocitem" index="22" name="Parent"/>
-    <alias field="parent_assetkinditem" index="23" name="Parent"/>
-    <alias field="parent_statusassetuseitem" index="24" name="Parent"/>
-    <alias field="parent_autoobjectcatitem" index="25" name="Parent"/>
-    <alias field="parent_contactkinditem" index="26" name="Parent"/>
-    <alias field="parent_assetformatitem" index="27" name="Parent"/>
-    <alias field="parent_mancatlabelitem" index="28" name="Parent"/>
-    <alias field="parent_autocatlabelitem" index="29" name="Parent"/>
-    <alias field="parent_pubchannelitem" index="30" name="Parent"/>
-    <alias field="parent_geomqualityitem" index="31" name="Parent"/>
+    <alias name="" field="T_Id" index="0"/>
+    <alias name="" field="T_basket" index="1"/>
+    <alias name="" field="T_Ili_Tid" index="2"/>
+    <alias name="Code" field="acode" index="3"/>
+    <alias name="GeolCode" field="geolcode" index="4"/>
+    <alias name="Name" field="aname" index="5"/>
+    <alias name="" field="aname_de" index="6"/>
+    <alias name="" field="aname_fr" index="7"/>
+    <alias name="" field="aname_rm" index="8"/>
+    <alias name="" field="aname_it" index="9"/>
+    <alias name="" field="aname_en" index="10"/>
+    <alias name="Description" field="adescription" index="11"/>
+    <alias name="" field="adescription_de" index="12"/>
+    <alias name="" field="adescription_fr" index="13"/>
+    <alias name="" field="adescription_rm" index="14"/>
+    <alias name="" field="adescription_it" index="15"/>
+    <alias name="" field="adescription_en" index="16"/>
+    <alias name="IsSuperItem" field="issuperitem" index="17"/>
+    <alias name="IsUseable" field="isuseable" index="18"/>
+    <alias name="Parent" field="parent_statusworkitem" index="19"/>
+    <alias name="Parent" field="parent_assetkinditem" index="20"/>
+    <alias name="Parent" field="parent_languageitem" index="21"/>
+    <alias name="Parent" field="parent_natrelitem" index="22"/>
+    <alias name="Parent" field="parent_mancatlabelitem" index="23"/>
+    <alias name="Parent" field="parent_autocatlabelitem" index="24"/>
+    <alias name="Parent" field="parent_contactkinditem" index="25"/>
+    <alias name="Parent" field="parent_assetformatitem" index="26"/>
+    <alias name="Parent" field="parent_statusassetuseitem" index="27"/>
+    <alias name="Parent" field="parent_legaldocitem" index="28"/>
+    <alias name="Parent" field="parent_geomqualityitem" index="29"/>
+    <alias name="Parent" field="parent_autoobjectcatitem" index="30"/>
+    <alias name="Parent" field="parent_pubchannelitem" index="31"/>
   </aliases>
   <defaults>
     <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
@@ -337,86 +320,86 @@
     <default field="issuperitem" expression="" applyOnUpdate="0"/>
     <default field="isuseable" expression="" applyOnUpdate="0"/>
     <default field="parent_statusworkitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_natrelitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_languageitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_legaldocitem" expression="" applyOnUpdate="0"/>
     <default field="parent_assetkinditem" expression="" applyOnUpdate="0"/>
-    <default field="parent_statusassetuseitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_autoobjectcatitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_contactkinditem" expression="" applyOnUpdate="0"/>
-    <default field="parent_assetformatitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_languageitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_natrelitem" expression="" applyOnUpdate="0"/>
     <default field="parent_mancatlabelitem" expression="" applyOnUpdate="0"/>
     <default field="parent_autocatlabelitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_pubchannelitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_contactkinditem" expression="" applyOnUpdate="0"/>
+    <default field="parent_assetformatitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_statusassetuseitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_legaldocitem" expression="" applyOnUpdate="0"/>
     <default field="parent_geomqualityitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_autoobjectcatitem" expression="" applyOnUpdate="0"/>
+    <default field="parent_pubchannelitem" expression="" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" notnull_strength="1" field="T_Id" exp_strength="0" constraints="3"/>
-    <constraint unique_strength="0" notnull_strength="1" field="T_basket" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="T_Ili_Tid" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="1" field="acode" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="geolcode" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname_de" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname_fr" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname_rm" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname_it" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="aname_en" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription_de" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription_fr" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription_rm" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription_it" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription_en" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="1" field="issuperitem" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="1" field="isuseable" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_statusworkitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_natrelitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_languageitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_legaldocitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_assetkinditem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_statusassetuseitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_autoobjectcatitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_contactkinditem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_assetformatitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_mancatlabelitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_autocatlabelitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_pubchannelitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="parent_geomqualityitem" exp_strength="0" constraints="0"/>
+    <constraint constraints="3" field="T_Id" unique_strength="1" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="1" field="T_basket" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="T_Ili_Tid" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="1" field="acode" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="geolcode" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_de" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_fr" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_rm" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_it" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="aname_en" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_de" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_fr" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_rm" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_it" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="adescription_en" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="1" field="issuperitem" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="1" field="isuseable" unique_strength="0" exp_strength="0" notnull_strength="1"/>
+    <constraint constraints="0" field="parent_statusworkitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_assetkinditem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_languageitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_natrelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_mancatlabelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_autocatlabelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_contactkinditem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_assetformatitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_statusassetuseitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_legaldocitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_geomqualityitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_autoobjectcatitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint constraints="0" field="parent_pubchannelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="T_Id" desc="" exp=""/>
-    <constraint field="T_basket" desc="" exp=""/>
-    <constraint field="T_Ili_Tid" desc="" exp=""/>
-    <constraint field="acode" desc="" exp=""/>
-    <constraint field="geolcode" desc="" exp=""/>
-    <constraint field="aname" desc="" exp=""/>
-    <constraint field="aname_de" desc="" exp=""/>
-    <constraint field="aname_fr" desc="" exp=""/>
-    <constraint field="aname_rm" desc="" exp=""/>
-    <constraint field="aname_it" desc="" exp=""/>
-    <constraint field="aname_en" desc="" exp=""/>
-    <constraint field="adescription" desc="" exp=""/>
-    <constraint field="adescription_de" desc="" exp=""/>
-    <constraint field="adescription_fr" desc="" exp=""/>
-    <constraint field="adescription_rm" desc="" exp=""/>
-    <constraint field="adescription_it" desc="" exp=""/>
-    <constraint field="adescription_en" desc="" exp=""/>
-    <constraint field="issuperitem" desc="" exp=""/>
-    <constraint field="isuseable" desc="" exp=""/>
-    <constraint field="parent_statusworkitem" desc="" exp=""/>
-    <constraint field="parent_natrelitem" desc="" exp=""/>
-    <constraint field="parent_languageitem" desc="" exp=""/>
-    <constraint field="parent_legaldocitem" desc="" exp=""/>
-    <constraint field="parent_assetkinditem" desc="" exp=""/>
-    <constraint field="parent_statusassetuseitem" desc="" exp=""/>
-    <constraint field="parent_autoobjectcatitem" desc="" exp=""/>
-    <constraint field="parent_contactkinditem" desc="" exp=""/>
-    <constraint field="parent_assetformatitem" desc="" exp=""/>
-    <constraint field="parent_mancatlabelitem" desc="" exp=""/>
-    <constraint field="parent_autocatlabelitem" desc="" exp=""/>
-    <constraint field="parent_pubchannelitem" desc="" exp=""/>
-    <constraint field="parent_geomqualityitem" desc="" exp=""/>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="T_Ili_Tid" desc=""/>
+    <constraint exp="" field="acode" desc=""/>
+    <constraint exp="" field="geolcode" desc=""/>
+    <constraint exp="" field="aname" desc=""/>
+    <constraint exp="" field="aname_de" desc=""/>
+    <constraint exp="" field="aname_fr" desc=""/>
+    <constraint exp="" field="aname_rm" desc=""/>
+    <constraint exp="" field="aname_it" desc=""/>
+    <constraint exp="" field="aname_en" desc=""/>
+    <constraint exp="" field="adescription" desc=""/>
+    <constraint exp="" field="adescription_de" desc=""/>
+    <constraint exp="" field="adescription_fr" desc=""/>
+    <constraint exp="" field="adescription_rm" desc=""/>
+    <constraint exp="" field="adescription_it" desc=""/>
+    <constraint exp="" field="adescription_en" desc=""/>
+    <constraint exp="" field="issuperitem" desc=""/>
+    <constraint exp="" field="isuseable" desc=""/>
+    <constraint exp="" field="parent_statusworkitem" desc=""/>
+    <constraint exp="" field="parent_assetkinditem" desc=""/>
+    <constraint exp="" field="parent_languageitem" desc=""/>
+    <constraint exp="" field="parent_natrelitem" desc=""/>
+    <constraint exp="" field="parent_mancatlabelitem" desc=""/>
+    <constraint exp="" field="parent_autocatlabelitem" desc=""/>
+    <constraint exp="" field="parent_contactkinditem" desc=""/>
+    <constraint exp="" field="parent_assetformatitem" desc=""/>
+    <constraint exp="" field="parent_statusassetuseitem" desc=""/>
+    <constraint exp="" field="parent_legaldocitem" desc=""/>
+    <constraint exp="" field="parent_geomqualityitem" desc=""/>
+    <constraint exp="" field="parent_autoobjectcatitem" desc=""/>
+    <constraint exp="" field="parent_pubchannelitem" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <editform tolerant="1"></editform>
@@ -425,23 +408,36 @@
   <editforminitfilepath></editforminitfilepath>
   <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
-QGIS-Formulare können eine Python-Funktion haben,, die aufgerufen wird, wenn sich das Formular öffnet
+QGIS forms can have a Python function that is called when the form is
+opened.
 
-Diese Funktion kann verwendet werden um dem Formular Extralogik hinzuzufügen.
+Use this function to add extra logic to your forms.
 
-Der Name der Funktion wird im Feld "Python Init-Function" angegeben
-Ein Beispiel folgt:
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
 """
 from qgis.PyQt.QtWidgets import QWidget
 
 def my_form_open(dialog, layer, feature):
-	geom = feature.geometry()
-	control = dialog.findChild(QWidget, "MyLineEdit")
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
 ]]></editforminitcode>
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorHtmlElement showLabel="0" name="Dummy to create empty form"></attributeEditorHtmlElement>
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="English" columnCount="1" groupBox="1" showLabel="1">
+      <attributeEditorField name="aname_en" index="10" showLabel="0"/>
+      <attributeEditorField name="adescription_en" index="16" showLabel="0"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="French" columnCount="1" groupBox="1" showLabel="1">
+      <attributeEditorField name="aname_fr" index="7" showLabel="0"/>
+      <attributeEditorField name="adescription_fr" index="13" showLabel="0"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="German" columnCount="1" groupBox="1" showLabel="1">
+      <attributeEditorField name="aname_de" index="6" showLabel="0"/>
+      <attributeEditorField name="adescription_de" index="12" showLabel="0"/>
+    </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
     <field name="T_Id" editable="1"/>
@@ -449,15 +445,15 @@ def my_form_open(dialog, layer, feature):
     <field name="T_basket" editable="1"/>
     <field name="acode" editable="1"/>
     <field name="adescription" editable="1"/>
-    <field name="adescription_de" editable="1"/>
-    <field name="adescription_en" editable="1"/>
-    <field name="adescription_fr" editable="1"/>
+    <field name="adescription_de" editable="0"/>
+    <field name="adescription_en" editable="0"/>
+    <field name="adescription_fr" editable="0"/>
     <field name="adescription_it" editable="1"/>
     <field name="adescription_rm" editable="1"/>
     <field name="aname" editable="1"/>
-    <field name="aname_de" editable="1"/>
+    <field name="aname_de" editable="0"/>
     <field name="aname_en" editable="1"/>
-    <field name="aname_fr" editable="1"/>
+    <field name="aname_fr" editable="0"/>
     <field name="aname_it" editable="1"/>
     <field name="aname_rm" editable="1"/>
     <field name="geolcode" editable="1"/>
@@ -478,74 +474,75 @@ def my_form_open(dialog, layer, feature):
     <field name="parent_statusworkitem" editable="1"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="T_Id"/>
-    <field labelOnTop="0" name="T_Ili_Tid"/>
-    <field labelOnTop="0" name="T_basket"/>
-    <field labelOnTop="0" name="acode"/>
-    <field labelOnTop="0" name="adescription"/>
-    <field labelOnTop="0" name="adescription_de"/>
-    <field labelOnTop="0" name="adescription_en"/>
-    <field labelOnTop="0" name="adescription_fr"/>
-    <field labelOnTop="0" name="adescription_it"/>
-    <field labelOnTop="0" name="adescription_rm"/>
-    <field labelOnTop="0" name="aname"/>
-    <field labelOnTop="0" name="aname_de"/>
-    <field labelOnTop="0" name="aname_en"/>
-    <field labelOnTop="0" name="aname_fr"/>
-    <field labelOnTop="0" name="aname_it"/>
-    <field labelOnTop="0" name="aname_rm"/>
-    <field labelOnTop="0" name="geolcode"/>
-    <field labelOnTop="0" name="issuperitem"/>
-    <field labelOnTop="0" name="isuseable"/>
-    <field labelOnTop="0" name="parent_assetformatitem"/>
-    <field labelOnTop="0" name="parent_assetkinditem"/>
-    <field labelOnTop="0" name="parent_autocatlabelitem"/>
-    <field labelOnTop="0" name="parent_autoobjectcatitem"/>
-    <field labelOnTop="0" name="parent_contactkinditem"/>
-    <field labelOnTop="0" name="parent_geomqualityitem"/>
-    <field labelOnTop="0" name="parent_languageitem"/>
-    <field labelOnTop="0" name="parent_legaldocitem"/>
-    <field labelOnTop="0" name="parent_mancatlabelitem"/>
-    <field labelOnTop="0" name="parent_natrelitem"/>
-    <field labelOnTop="0" name="parent_pubchannelitem"/>
-    <field labelOnTop="0" name="parent_statusassetuseitem"/>
-    <field labelOnTop="0" name="parent_statusworkitem"/>
+    <field name="T_Id" labelOnTop="0"/>
+    <field name="T_Ili_Tid" labelOnTop="0"/>
+    <field name="T_basket" labelOnTop="0"/>
+    <field name="acode" labelOnTop="0"/>
+    <field name="adescription" labelOnTop="0"/>
+    <field name="adescription_de" labelOnTop="0"/>
+    <field name="adescription_en" labelOnTop="0"/>
+    <field name="adescription_fr" labelOnTop="0"/>
+    <field name="adescription_it" labelOnTop="0"/>
+    <field name="adescription_rm" labelOnTop="0"/>
+    <field name="aname" labelOnTop="0"/>
+    <field name="aname_de" labelOnTop="0"/>
+    <field name="aname_en" labelOnTop="0"/>
+    <field name="aname_fr" labelOnTop="0"/>
+    <field name="aname_it" labelOnTop="0"/>
+    <field name="aname_rm" labelOnTop="0"/>
+    <field name="geolcode" labelOnTop="0"/>
+    <field name="issuperitem" labelOnTop="0"/>
+    <field name="isuseable" labelOnTop="0"/>
+    <field name="parent_assetformatitem" labelOnTop="0"/>
+    <field name="parent_assetkinditem" labelOnTop="0"/>
+    <field name="parent_autocatlabelitem" labelOnTop="0"/>
+    <field name="parent_autoobjectcatitem" labelOnTop="0"/>
+    <field name="parent_contactkinditem" labelOnTop="0"/>
+    <field name="parent_geomqualityitem" labelOnTop="0"/>
+    <field name="parent_languageitem" labelOnTop="0"/>
+    <field name="parent_legaldocitem" labelOnTop="0"/>
+    <field name="parent_mancatlabelitem" labelOnTop="0"/>
+    <field name="parent_natrelitem" labelOnTop="0"/>
+    <field name="parent_pubchannelitem" labelOnTop="0"/>
+    <field name="parent_statusassetuseitem" labelOnTop="0"/>
+    <field name="parent_statusworkitem" labelOnTop="0"/>
   </labelOnTop>
   <reuseLastValue>
-    <field reuseLastValue="0" name="T_Id"/>
-    <field reuseLastValue="0" name="T_Ili_Tid"/>
-    <field reuseLastValue="0" name="T_basket"/>
-    <field reuseLastValue="0" name="acode"/>
-    <field reuseLastValue="0" name="adescription"/>
-    <field reuseLastValue="0" name="adescription_de"/>
-    <field reuseLastValue="0" name="adescription_en"/>
-    <field reuseLastValue="0" name="adescription_fr"/>
-    <field reuseLastValue="0" name="adescription_it"/>
-    <field reuseLastValue="0" name="adescription_rm"/>
-    <field reuseLastValue="0" name="aname"/>
-    <field reuseLastValue="0" name="aname_de"/>
-    <field reuseLastValue="0" name="aname_en"/>
-    <field reuseLastValue="0" name="aname_fr"/>
-    <field reuseLastValue="0" name="aname_it"/>
-    <field reuseLastValue="0" name="aname_rm"/>
-    <field reuseLastValue="0" name="geolcode"/>
-    <field reuseLastValue="0" name="issuperitem"/>
-    <field reuseLastValue="0" name="isuseable"/>
-    <field reuseLastValue="0" name="parent_assetformatitem"/>
-    <field reuseLastValue="0" name="parent_assetkinditem"/>
-    <field reuseLastValue="0" name="parent_autocatlabelitem"/>
-    <field reuseLastValue="0" name="parent_autoobjectcatitem"/>
-    <field reuseLastValue="0" name="parent_contactkinditem"/>
-    <field reuseLastValue="0" name="parent_geomqualityitem"/>
-    <field reuseLastValue="0" name="parent_languageitem"/>
-    <field reuseLastValue="0" name="parent_legaldocitem"/>
-    <field reuseLastValue="0" name="parent_mancatlabelitem"/>
-    <field reuseLastValue="0" name="parent_natrelitem"/>
-    <field reuseLastValue="0" name="parent_pubchannelitem"/>
-    <field reuseLastValue="0" name="parent_statusassetuseitem"/>
-    <field reuseLastValue="0" name="parent_statusworkitem"/>
+    <field name="T_Id" reuseLastValue="0"/>
+    <field name="T_Ili_Tid" reuseLastValue="0"/>
+    <field name="T_basket" reuseLastValue="0"/>
+    <field name="acode" reuseLastValue="0"/>
+    <field name="adescription" reuseLastValue="0"/>
+    <field name="adescription_de" reuseLastValue="0"/>
+    <field name="adescription_en" reuseLastValue="0"/>
+    <field name="adescription_fr" reuseLastValue="0"/>
+    <field name="adescription_it" reuseLastValue="0"/>
+    <field name="adescription_rm" reuseLastValue="0"/>
+    <field name="aname" reuseLastValue="0"/>
+    <field name="aname_de" reuseLastValue="0"/>
+    <field name="aname_en" reuseLastValue="0"/>
+    <field name="aname_fr" reuseLastValue="0"/>
+    <field name="aname_it" reuseLastValue="0"/>
+    <field name="aname_rm" reuseLastValue="0"/>
+    <field name="geolcode" reuseLastValue="0"/>
+    <field name="issuperitem" reuseLastValue="0"/>
+    <field name="isuseable" reuseLastValue="0"/>
+    <field name="parent_assetformatitem" reuseLastValue="0"/>
+    <field name="parent_assetkinditem" reuseLastValue="0"/>
+    <field name="parent_autocatlabelitem" reuseLastValue="0"/>
+    <field name="parent_autoobjectcatitem" reuseLastValue="0"/>
+    <field name="parent_contactkinditem" reuseLastValue="0"/>
+    <field name="parent_geomqualityitem" reuseLastValue="0"/>
+    <field name="parent_languageitem" reuseLastValue="0"/>
+    <field name="parent_legaldocitem" reuseLastValue="0"/>
+    <field name="parent_mancatlabelitem" reuseLastValue="0"/>
+    <field name="parent_natrelitem" reuseLastValue="0"/>
+    <field name="parent_pubchannelitem" reuseLastValue="0"/>
+    <field name="parent_statusassetuseitem" reuseLastValue="0"/>
+    <field name="parent_statusworkitem" reuseLastValue="0"/>
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>
+  <previewExpression>"aname_de"</previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/projecttopping/lg_geolassets_v2_gpkg.yaml
+++ b/lg_geolassets_v2/projecttopping/lg_geolassets_v2_gpkg.yaml
@@ -27,46 +27,58 @@ layertree:
         group: true
         expanded: false
         child-nodes:
-          - "Address":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_address"
-          - "ID":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_id"
-          - "TypeNatRel":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_typenatrel"
-          - "StatusWork":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_statuswork"
-          - "AutoCat":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_autocat"
-          - "InternalUse":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_internaluse"
-          - "PublicUse":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_publicuse"
-          - "AssetObjectInfo":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetobjectinfo"
-          - "LegalDoc":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_legaldoc"
-          - "ManCatLabelItem":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_mancatlabelitem"
-          - "AssetKindItem":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetkinditem"
-          - "AssetFormatItem":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetformatitem"
-          - "NatRelItem":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_natrelitem"
-          - "StatusWorkItem":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_statusworkitem"
-          - "AssetItem_Contact_Author":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_contact_author"
-          - "AssetItem_Contact_Initiator":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_contact_initiator"
-          - "AssetItem_Contact_Supplier":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_contact_supplier"
-          - "AssetItem_Publication":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_publication"
-          - "AssetItem_UsedBy":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_usedby"
-          - "AssetItemX_AssetItemY":
-              qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitemx_assetitemy"
+            - "Strukturtabellen":
+                group: true
+                expanded: false
+                child-nodes:
+                    - "Address":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_address"
+                    - "ID":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_id"
+                    - "TypeNatRel":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_typenatrel"
+                    - "StatusWork":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_statuswork"
+                    - "AutoCat":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_autocat"
+                    - "InternalUse":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_internaluse"
+                    - "PublicUse":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_publicuse"
+                    - "AssetObjectInfo":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetobjectinfo"
+                    - "LegalDoc":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_legaldoc"
+            - "Domänentabellen":
+                group: true
+                expanded: false
+                child-nodes:
+                    - "ManCatLabelItem":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_mancatlabelitem"
+                    - "AssetKindItem":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetkinditem"
+                    - "AssetFormatItem":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetformatitem"
+                    - "NatRelItem":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_natrelitem"
+                    - "StatusWorkItem":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_statusworkitem"
+            - "Verknüpfungstabellen":
+                group: true
+                expanded: false
+                child-nodes:
+                    - "AssetItem_Contact_Author":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_contact_author"
+                    - "AssetItem_Contact_Initiator":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_contact_initiator"
+                    - "AssetItem_Contact_Supplier":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_contact_supplier"
+                    - "AssetItem_Publication":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_publication"
+                    - "AssetItem_UsedBy":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_usedby"
+                    - "AssetItemX_AssetItemY":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitemx_assetitemy"
 
 properties:
     transaction_mode: "AutomaticGroups"


### PR DESCRIPTION
- Umbenennung des Reiters "AssetMain Attribute" zu "Teilassets" (denn dieser Reiter beschreibt die Teilassets, sofern der Asset selbst kein Teilasset ist). Generell ist die Sprache nun nicht von Parts oder Extracts sondern von Teilassets. Siehe dafür auch "Teilasset" in "Eigenschaften" vom Reiter "Allgemein".
- Teilassets (ehemals AssetMain Attribute) Tab hab ich an das Ende genommen. Damit man eher nicht unwillentlich drauf klickt. Wegen des Bugs, dass man den Fokus in der Attributtabelle verliert. Ebenso hab ich ein virtuelles Info-Feld hinzugefügt.
- Manuell vergebene Layers / Type(n) Nationaler Relevanz und Arten der Parts (in Asset Main Attribute) sind nun deutsch und im Formular nebanan sieht man die Werte in anderen Sprachen.
- Format Items (AssetFormatItem) haben zur Ansicht nun auch eine schönere Formularformatierung.
- Verknüpfungswidgets, die nur ein Eintrag erlauben haben nun ein dafür optimiertes Widget, das keine Erfassung mehrerer Kinder erlaubt. In AssetItem: Asset Part Info, Interne Nutzung, Öffentliche Nutzung, Automatisch zugewiesene Klasse (in Info KI). Contact: Addresse. Dazu muss aber noch das Plugin "Linking Relation Editor" aktualisiert werden: "Plugins" > "Manage Install Plugins" > Search for: "Linking Relation Editor" > "Upgrade Plugin"
- Rechtsklick auf Feature in Attributtablle ("Öffne Formular einzlen") um einzelnes Formular zu öffnen. Wegen des Bugs, dass man den Fokus in der Attributtabelle verliert. Zusätzlich eine Info im Reiter "Teilassets", dass man das Formular so öffnen soll.
- Strukturierung der Hilfstabellen (primär für meine eigene Übersicht)