### PR TITLE
Followup 3 - Abfragen etc.

### DIFF
--- a/ilidata.xml
+++ b/ilidata.xml
@@ -2187,6 +2187,36 @@
 					</DatasetIdx16.DataFile>
 				</files>
 			</DatasetIdx16.DataIndex.DatasetMetadata>
+			<DatasetIdx16.DataIndex.DatasetMetadata TID="bf9fd010-50ae-402b-b757-d7e1293b9874">
+				<id>lg_geolassets_v2.qgis_layerstyle_mancatlabelref</id>
+				<version>2022-05-11</version>
+				<publishingDate>2022-08-31</publishingDate>
+				<owner>mailto:info@swisstopo.ch</owner>
+				<title>
+					<DatasetIdx16.MultilingualText>
+						<LocalisedText>
+							<DatasetIdx16.LocalisedText>
+								<Text>QGIS layerstyle file for lg_geolassets_v2 - mancatlabelref</Text>
+							</DatasetIdx16.LocalisedText>
+						</LocalisedText>
+					</DatasetIdx16.MultilingualText>
+				</title>
+				<categories>
+					<DatasetIdx16.Code_>
+						<value>http://codes.interlis.ch/type/layerstyle</value>
+					</DatasetIdx16.Code_>
+				</categories>
+				<files>
+					<DatasetIdx16.DataFile>
+						<fileFormat>text/plain</fileFormat>
+						<file>
+							<DatasetIdx16.File>
+								<path>./lg_geolassets_v2/layerstyle/mancatlabelref.qml</path>
+							</DatasetIdx16.File>
+						</file>
+					</DatasetIdx16.DataFile>
+				</files>
+			</DatasetIdx16.DataIndex.DatasetMetadata>
 			<DatasetIdx16.DataIndex.DatasetMetadata TID="19a39a6f-d3c5-45b3-8f6c-125009528684">
 				<id>lg_geolassets_v2.qgis_layerstyle_assetitemx_assetitemy</id>
 				<version>2022-05-11</version>

--- a/lg_geolassets_v2/layerstyle/assetitem.qml
+++ b/lg_geolassets_v2/layerstyle/assetitem.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" styleCategories="LayerConfiguration|Fields|Forms|Actions" version="3.24.3-Tisler">
+<qgis styleCategories="LayerConfiguration|Fields|Forms|Actions" readOnly="0" version="3.24.3-Tisler">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -40,7 +40,10 @@
     <field name="T_Ili_Tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
-          <Option/>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
         </config>
       </editWidget>
     </field>
@@ -401,100 +404,100 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" field="T_Id" index="0"/>
-    <alias name="" field="T_basket" index="1"/>
-    <alias name="" field="T_Ili_Tid" index="2"/>
-    <alias name="Ist relevant" field="isnatrel" index="3"/>
-    <alias name="Eingangsdatum" field="datereceipt" index="4"/>
-    <alias name="Gemeinde" field="municipality" index="5"/>
-    <alias name="URL zu einer Online-Ressource" field="url" index="6"/>
-    <alias name="File" field="relativepath" index="7"/>
-    <alias name="Physischer Standort des analogen Dokuments" field="locationanalog" index="8"/>
-    <alias name="Bearbeiter" field="processor" index="9"/>
-    <alias name="Letztes Bearbeitungsdatum" field="datelastprocessed" index="10"/>
-    <alias name="Textkörper" field="textbody" index="11"/>
-    <alias name="Sonstige Bemerkungen" field="remark" index="12"/>
-    <alias name="IDSGS" field="idsgs" index="13"/>
-    <alias name="Daten" field="infogeoldata" index="14"/>
-    <alias name="Kontaktinformationen" field="infogeolcontactdata" index="15"/>
-    <alias name="Auxiliary Information" field="infogeolauxdata" index="16"/>
-    <alias name="Öffentlicher Titel" field="titlepublic" index="17"/>
-    <alias name="Original Titel" field="titleoriginal" index="18"/>
-    <alias name="Art" field="akind" index="19"/>
-    <alias name="Asset-Erstellungsdatum" field="datecreation" index="20"/>
-    <alias name="Sprache" field="alanguage" index="21"/>
-    <alias name="Format" field="aformat" index="22"/>
-    <alias name="Autoren" field="authorbiblio" index="23"/>
-    <alias name="Projekt im Rahmen dessen das Asset erstellt wurde" field="sourceproject" index="24"/>
-    <alias name="Beschreibung" field="adescription" index="25"/>
-    <alias name="Dieser Asset ist ein Teilasset" field="isextract" index="26"/>
-    <alias name="AssetItemMain" field="assetitemmain_assetitem" index="27"/>
-    <alias name="Hauptasset (von dem dieses AssetItem ein Teil ist)" field="assetitemmain_lg_geolssts_v2geolassets_assetitem" index="28"/>
-    <alias name="" field="Teilasset Info" index="29"/>
+    <alias name="" index="0" field="T_Id"/>
+    <alias name="" index="1" field="T_basket"/>
+    <alias name="" index="2" field="T_Ili_Tid"/>
+    <alias name="Ist relevant" index="3" field="isnatrel"/>
+    <alias name="Eingangsdatum" index="4" field="datereceipt"/>
+    <alias name="Gemeinde" index="5" field="municipality"/>
+    <alias name="URL zu einer Online-Ressource" index="6" field="url"/>
+    <alias name="File" index="7" field="relativepath"/>
+    <alias name="Physischer Standort des analogen Dokuments" index="8" field="locationanalog"/>
+    <alias name="Bearbeiter" index="9" field="processor"/>
+    <alias name="Letztes Bearbeitungsdatum" index="10" field="datelastprocessed"/>
+    <alias name="Textkörper" index="11" field="textbody"/>
+    <alias name="Sonstige Bemerkungen" index="12" field="remark"/>
+    <alias name="IDSGS" index="13" field="idsgs"/>
+    <alias name="Daten" index="14" field="infogeoldata"/>
+    <alias name="Kontaktinformationen" index="15" field="infogeolcontactdata"/>
+    <alias name="Auxiliary Information" index="16" field="infogeolauxdata"/>
+    <alias name="Öffentlicher Titel" index="17" field="titlepublic"/>
+    <alias name="Original Titel" index="18" field="titleoriginal"/>
+    <alias name="Art" index="19" field="akind"/>
+    <alias name="Asset-Erstellungsdatum" index="20" field="datecreation"/>
+    <alias name="Sprache" index="21" field="alanguage"/>
+    <alias name="Format" index="22" field="aformat"/>
+    <alias name="Autoren" index="23" field="authorbiblio"/>
+    <alias name="Projekt im Rahmen dessen das Asset erstellt wurde" index="24" field="sourceproject"/>
+    <alias name="Beschreibung" index="25" field="adescription"/>
+    <alias name="Dieser Asset ist ein Teilasset" index="26" field="isextract"/>
+    <alias name="AssetItemMain" index="27" field="assetitemmain_assetitem"/>
+    <alias name="Hauptasset (von dem dieses AssetItem ein Teil ist)" index="28" field="assetitemmain_lg_geolssts_v2geolassets_assetitem"/>
+    <alias name="" index="29" field="Teilasset Info"/>
   </aliases>
   <defaults>
-    <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
-    <default field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets" applyOnUpdate="0"/>
-    <default field="T_Ili_Tid" expression="substr(uuid(), 2, 36)" applyOnUpdate="0"/>
-    <default field="isnatrel" expression="" applyOnUpdate="0"/>
-    <default field="datereceipt" expression="" applyOnUpdate="0"/>
-    <default field="municipality" expression="" applyOnUpdate="0"/>
-    <default field="url" expression="" applyOnUpdate="0"/>
-    <default field="relativepath" expression="" applyOnUpdate="0"/>
-    <default field="locationanalog" expression="" applyOnUpdate="0"/>
-    <default field="processor" expression="" applyOnUpdate="0"/>
-    <default field="datelastprocessed" expression="now()" applyOnUpdate="0"/>
-    <default field="textbody" expression="" applyOnUpdate="0"/>
-    <default field="remark" expression="" applyOnUpdate="0"/>
-    <default field="idsgs" expression="" applyOnUpdate="0"/>
-    <default field="infogeoldata" expression="" applyOnUpdate="0"/>
-    <default field="infogeolcontactdata" expression="" applyOnUpdate="0"/>
-    <default field="infogeolauxdata" expression="" applyOnUpdate="0"/>
-    <default field="titlepublic" expression="" applyOnUpdate="0"/>
-    <default field="titleoriginal" expression="" applyOnUpdate="0"/>
-    <default field="akind" expression="" applyOnUpdate="0"/>
-    <default field="datecreation" expression="" applyOnUpdate="0"/>
-    <default field="alanguage" expression="" applyOnUpdate="0"/>
-    <default field="aformat" expression="attribute(get_feature('AssetFormatItem', 'Code', 'pdf'), 'T_Id')" applyOnUpdate="0"/>
-    <default field="authorbiblio" expression="" applyOnUpdate="0"/>
-    <default field="sourceproject" expression="" applyOnUpdate="0"/>
-    <default field="adescription" expression="" applyOnUpdate="0"/>
-    <default field="isextract" expression="false" applyOnUpdate="0"/>
-    <default field="assetitemmain_assetitem" expression="" applyOnUpdate="0"/>
-    <default field="assetitemmain_lg_geolssts_v2geolassets_assetitem" expression="" applyOnUpdate="0"/>
-    <default field="Teilasset Info" expression="'Dieser Reiter wird nur angezeigt, wenn das AssetItem selbst kein Teilasset ist.'" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
+    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
+    <default applyOnUpdate="0" field="T_Ili_Tid" expression="substr(uuid(), 2, 36)"/>
+    <default applyOnUpdate="0" field="isnatrel" expression=""/>
+    <default applyOnUpdate="0" field="datereceipt" expression=""/>
+    <default applyOnUpdate="0" field="municipality" expression=""/>
+    <default applyOnUpdate="0" field="url" expression=""/>
+    <default applyOnUpdate="0" field="relativepath" expression=""/>
+    <default applyOnUpdate="0" field="locationanalog" expression=""/>
+    <default applyOnUpdate="0" field="processor" expression=""/>
+    <default applyOnUpdate="0" field="datelastprocessed" expression="now()"/>
+    <default applyOnUpdate="0" field="textbody" expression=""/>
+    <default applyOnUpdate="0" field="remark" expression=""/>
+    <default applyOnUpdate="0" field="idsgs" expression=""/>
+    <default applyOnUpdate="0" field="infogeoldata" expression=""/>
+    <default applyOnUpdate="0" field="infogeolcontactdata" expression=""/>
+    <default applyOnUpdate="0" field="infogeolauxdata" expression=""/>
+    <default applyOnUpdate="0" field="titlepublic" expression=""/>
+    <default applyOnUpdate="0" field="titleoriginal" expression=""/>
+    <default applyOnUpdate="0" field="akind" expression=""/>
+    <default applyOnUpdate="0" field="datecreation" expression=""/>
+    <default applyOnUpdate="0" field="alanguage" expression=""/>
+    <default applyOnUpdate="0" field="aformat" expression="attribute(get_feature('AssetFormatItem', 'Code', 'pdf'), 'T_Id')"/>
+    <default applyOnUpdate="0" field="authorbiblio" expression=""/>
+    <default applyOnUpdate="0" field="sourceproject" expression=""/>
+    <default applyOnUpdate="0" field="adescription" expression=""/>
+    <default applyOnUpdate="0" field="isextract" expression="false"/>
+    <default applyOnUpdate="0" field="assetitemmain_assetitem" expression=""/>
+    <default applyOnUpdate="0" field="assetitemmain_lg_geolssts_v2geolassets_assetitem" expression=""/>
+    <default applyOnUpdate="0" field="Teilasset Info" expression="'Dieser Reiter wird nur angezeigt, wenn das AssetItem selbst kein Teilasset ist.'"/>
   </defaults>
   <constraints>
-    <constraint constraints="3" field="T_Id" unique_strength="1" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="1" field="T_basket" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="0" field="T_Ili_Tid" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="1" field="isnatrel" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="1" field="datereceipt" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="0" field="municipality" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="url" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="1" field="relativepath" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="0" field="locationanalog" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="processor" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="1" field="datelastprocessed" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="0" field="textbody" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="remark" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="idsgs" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="infogeoldata" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="infogeolcontactdata" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="infogeolauxdata" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="titlepublic" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="1" field="titleoriginal" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="1" field="akind" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="1" field="datecreation" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="1" field="alanguage" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="1" field="aformat" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="0" field="authorbiblio" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="sourceproject" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="adescription" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="1" field="isextract" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="0" field="assetitemmain_assetitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="assetitemmain_lg_geolssts_v2geolassets_assetitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="Teilasset Info" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="1" constraints="2" field="T_Ili_Tid" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="isnatrel" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="datereceipt" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="municipality" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="url" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="relativepath" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="locationanalog" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="processor" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="datelastprocessed" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="textbody" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="remark" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="idsgs" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="infogeoldata" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="infogeolcontactdata" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="infogeolauxdata" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="titlepublic" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="titleoriginal" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="akind" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="datecreation" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="alanguage" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="aformat" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="authorbiblio" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="sourceproject" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="adescription" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="isextract" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="assetitemmain_assetitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="assetitemmain_lg_geolssts_v2geolassets_assetitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="Teilasset Info" notnull_strength="0" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="T_Id" desc=""/>
@@ -529,11 +532,11 @@
     <constraint exp="" field="Teilasset Info" desc=""/>
   </constraintExpressions>
   <expressionfields>
-    <field typeName="string" name="Teilasset Info" subType="0" expression="'Dieser Reiter wird nur angezeigt, wenn das AssetItem selbst kein Teilasset ist.&#xa;&#xa;Hier besteht ein Bug, dass QGIS in der Attributtabelle den Fokus auf den aktuellen Asset verliert. Falls du diesen Reiter in der Attributtabelle direkt (nicht über &quot;Öffne Formular einzeln&quot; angewählt hast), schliesse die Attributtabelle und öffne sie erneut.'" type="10" length="0" precision="0" comment=""/>
+    <field name="Teilasset Info" type="10" precision="0" comment="" typeName="string" expression="'Dieser Reiter wird nur angezeigt, wenn das AssetItem selbst kein Teilasset ist.&#xa;&#xa;Hier besteht ein Bug, dass QGIS in der Attributtabelle den Fokus auf den aktuellen Asset verliert. Falls du diesen Reiter in der Attributtabelle direkt (nicht über &quot;Öffne Formular einzeln&quot; angewählt hast), schliesse die Attributtabelle und öffne sie erneut.'" length="0" subType="0"/>
   </expressionfields>
   <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
-    <actionsetting shortTitle="Open Single Form" action="project = QgsProject.instance()&#xa;layer = QgsProject.instance().mapLayer('[% @layer_id %]')&#xa;feature =  layer.getFeature( [% $id %] )&#xa;form = qgis.utils.iface.getFeatureForm(layer, feature)&#xa;form.show()" id="{2c81fad2-2b72-42e5-b823-ddfbcec13d8b}" name="Öffne Formular einzeln" icon="" type="1" notificationMessage="" isEnabledOnlyWhenEditable="0" capture="0">
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+    <actionsetting name="Öffne Formular einzeln" type="1" id="{2c81fad2-2b72-42e5-b823-ddfbcec13d8b}" icon="" action="project = QgsProject.instance()&#xa;layer = QgsProject.instance().mapLayer('[% @layer_id %]')&#xa;feature =  layer.getFeature( [% $id %] )&#xa;form = qgis.utils.iface.getFeatureForm(layer, feature)&#xa;form.show()" isEnabledOnlyWhenEditable="0" capture="0" shortTitle="Open Single Form" notificationMessage="">
       <actionScope id="Feature"/>
     </actionsetting>
   </attributeactions>
@@ -559,15 +562,15 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Info *" columnCount="2" groupBox="0" showLabel="1">
-      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Titel" columnCount="1" groupBox="1" showLabel="1">
+    <attributeEditorContainer name="Info *" visibilityExpression="" columnCount="2" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorContainer name="Titel" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
         <attributeEditorField name="titleoriginal" index="18" showLabel="1"/>
         <attributeEditorField name="titlepublic" index="17" showLabel="1"/>
         <attributeEditorField name="sourceproject" index="24" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Identifikatoren" columnCount="1" groupBox="1" showLabel="1">
+      <attributeEditorContainer name="Identifikatoren" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
         <attributeEditorField name="idsgs" index="13" showLabel="1"/>
-        <attributeEditorRelation forceSuppressFormPopup="0" name="id_lg_glssts_vssts_ssttem_idalternate_lg_geolssts_v2geolassets_assetitem_T_Id" label="IDs" relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="1" relation="id_lg_glssts_vssts_ssttem_idalternate_lg_geolssts_v2geolassets_assetitem_T_Id">
+        <attributeEditorRelation name="id_lg_glssts_vssts_ssttem_idalternate_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="" label="IDs" relation="id_lg_glssts_vssts_ssttem_idalternate_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="1">
           <editor_configuration type="Map">
             <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature"/>
             <Option name="show_first_feature" type="bool" value="true"/>
@@ -575,12 +578,12 @@ def my_form_open(dialog, layer, feature):
         </attributeEditorRelation>
       </attributeEditorContainer>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Allgemein *" columnCount="2" groupBox="0" showLabel="1">
-      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Beschreibung" columnCount="1" groupBox="1" showLabel="1">
+    <attributeEditorContainer name="Allgemein *" visibilityExpression="" columnCount="2" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorContainer name="Beschreibung" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
         <attributeEditorField name="datecreation" index="20" showLabel="1"/>
         <attributeEditorField name="alanguage" index="21" showLabel="1"/>
-        <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" backgroundColor="#ffe0b2" name="Manuell vergebe Label (mindestens ein Eintrag)" columnCount="1" groupBox="1" showLabel="1">
-          <attributeEditorRelation forceSuppressFormPopup="0" name="mancatlabelref_lg_glssts_vssts_ssttem_mancatlabel_lg_geolssts_v2geolassets_assetitem_T_Id" label="Manuell vergebe Label (mindestens ein Eintrag)" relationWidgetTypeId="relation_editor" nmRelationId="mancatlabelref_areference_mancatlabelitem_T_Id" showLabel="0" relation="mancatlabelref_lg_glssts_vssts_ssttem_mancatlabel_lg_geolssts_v2geolassets_assetitem_T_Id">
+        <attributeEditorContainer name="Manuell vergebe Label (mindestens ein Eintrag)" visibilityExpression="" columnCount="1" backgroundColor="#ffe0b2" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
+          <attributeEditorRelation name="mancatlabelref_lg_glssts_vssts_ssttem_mancatlabel_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="mancatlabelref_areference_mancatlabelitem_T_Id" label="Manuell vergebe Label (mindestens ein Eintrag)" relation="mancatlabelref_lg_glssts_vssts_ssttem_mancatlabel_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="0">
             <editor_configuration type="Map">
               <Option name="buttons" type="QString" value="Link|Unlink"/>
               <Option name="show_first_feature" type="bool" value="true"/>
@@ -591,12 +594,12 @@ def my_form_open(dialog, layer, feature):
         <attributeEditorField name="authorbiblio" index="23" showLabel="1"/>
         <attributeEditorField name="remark" index="12" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Eigenschaften" columnCount="1" groupBox="1" showLabel="1">
-        <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Format" columnCount="1" groupBox="1" showLabel="1">
+      <attributeEditorContainer name="Eigenschaften" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
+        <attributeEditorContainer name="Format" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
           <attributeEditorField name="akind" index="19" showLabel="1"/>
           <attributeEditorField name="aformat" index="22" showLabel="1"/>
-          <attributeEditorContainer visibilityExpressionEnabled="1" visibilityExpression="attribute(get_feature('AssetKindItem', 't_id', akind),'code') is 'package'" name="Formate der Teile" columnCount="1" groupBox="1" showLabel="1">
-            <attributeEditorRelation forceSuppressFormPopup="0" name="assetformatref_lg_glssts_vssts_ssttem_formatcomposition_lg_geolssts_v2geolassets_assetitem_T_Id" label="Formate der Parts" relationWidgetTypeId="relation_editor" nmRelationId="assetformatref_areference_assetformatitem_T_Id" showLabel="0" relation="assetformatref_lg_glssts_vssts_ssttem_formatcomposition_lg_geolssts_v2geolassets_assetitem_T_Id">
+          <attributeEditorContainer name="Formate der Teile" visibilityExpression="attribute(get_feature('AssetKindItem', 't_id', akind),'code') is 'package'" columnCount="1" visibilityExpressionEnabled="1" groupBox="1" showLabel="1">
+            <attributeEditorRelation name="assetformatref_lg_glssts_vssts_ssttem_formatcomposition_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="assetformatref_areference_assetformatitem_T_Id" label="Formate der Parts" relation="assetformatref_lg_glssts_vssts_ssttem_formatcomposition_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="0">
               <editor_configuration type="Map">
                 <Option name="buttons" type="QString" value="AllButtons"/>
                 <Option name="show_first_feature" type="bool" value="true"/>
@@ -604,12 +607,12 @@ def my_form_open(dialog, layer, feature):
             </attributeEditorRelation>
           </attributeEditorContainer>
         </attributeEditorContainer>
-        <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Teilasset" columnCount="1" groupBox="1" showLabel="1">
+        <attributeEditorContainer name="Teilasset" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
           <attributeEditorField name="isextract" index="26" showLabel="1"/>
-          <attributeEditorContainer visibilityExpressionEnabled="1" visibilityExpression="&quot;isextract&quot;" name="Eigenschaften" columnCount="1" groupBox="1" showLabel="1">
+          <attributeEditorContainer name="Eigenschaften" visibilityExpression="&quot;isextract&quot;" columnCount="1" visibilityExpressionEnabled="1" groupBox="1" showLabel="1">
             <attributeEditorField name="assetitemmain_lg_geolssts_v2geolassets_assetitem" index="28" showLabel="1"/>
-            <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" backgroundColor="#ffe0b2" name="Teilasset Info" columnCount="1" groupBox="1" showLabel="1">
-              <attributeEditorRelation forceSuppressFormPopup="0" name="assetobjectinfo_lg_glssts_vssts_ssttem_assetobjectinfo_lg_geolssts_v2geolassets_assetitem_T_Id" label="Asset Part Info (nur ein Eintrag)" relationWidgetTypeId="linking_relation_editor" nmRelationId="one_to_one" showLabel="0" relation="assetobjectinfo_lg_glssts_vssts_ssttem_assetobjectinfo_lg_geolssts_v2geolassets_assetitem_T_Id">
+            <attributeEditorContainer name="Teilasset Info" visibilityExpression="" columnCount="1" backgroundColor="#ffe0b2" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
+              <attributeEditorRelation name="assetobjectinfo_lg_glssts_vssts_ssttem_assetobjectinfo_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="one_to_one" label="Asset Part Info (nur ein Eintrag)" relation="assetobjectinfo_lg_glssts_vssts_ssttem_assetobjectinfo_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="linking_relation_editor" forceSuppressFormPopup="0" showLabel="0">
                 <editor_configuration type="Map">
                   <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature"/>
                   <Option name="one_to_one" type="bool" value="true"/>
@@ -621,10 +624,10 @@ def my_form_open(dialog, layer, feature):
         </attributeEditorContainer>
       </attributeEditorContainer>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Nutzung" columnCount="2" groupBox="0" showLabel="1">
-      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Nutzung" columnCount="1" groupBox="1" showLabel="1">
-        <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" backgroundColor="#ffe0b2" name="Interne Nutzung" columnCount="1" groupBox="1" showLabel="1">
-          <attributeEditorRelation forceSuppressFormPopup="0" name="internaluse_lg_glssts_vssts_ssttem_internaluse_lg_geolssts_v2geolassets_assetitem_T_Id" label="Interne Nutzung" relationWidgetTypeId="linking_relation_editor" nmRelationId="one_to_one" showLabel="0" relation="internaluse_lg_glssts_vssts_ssttem_internaluse_lg_geolssts_v2geolassets_assetitem_T_Id">
+    <attributeEditorContainer name="Nutzung" visibilityExpression="" columnCount="2" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorContainer name="Nutzung" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
+        <attributeEditorContainer name="Interne Nutzung" visibilityExpression="" columnCount="1" backgroundColor="#ffe0b2" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
+          <attributeEditorRelation name="internaluse_lg_glssts_vssts_ssttem_internaluse_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="one_to_one" label="Interne Nutzung" relation="internaluse_lg_glssts_vssts_ssttem_internaluse_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="linking_relation_editor" forceSuppressFormPopup="0" showLabel="0">
             <editor_configuration type="Map">
               <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature"/>
               <Option name="one_to_one" type="bool" value="true"/>
@@ -632,8 +635,8 @@ def my_form_open(dialog, layer, feature):
             </editor_configuration>
           </attributeEditorRelation>
         </attributeEditorContainer>
-        <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" backgroundColor="#ffe0b2" name="Öffentliche Nutzung" columnCount="1" groupBox="1" showLabel="1">
-          <attributeEditorRelation forceSuppressFormPopup="0" name="publicuse_lg_glssts_vssts_ssttem_publicuse_lg_geolssts_v2geolassets_assetitem_T_Id" label="Öffentliche Nutzung" relationWidgetTypeId="linking_relation_editor" nmRelationId="one_to_one" showLabel="0" relation="publicuse_lg_glssts_vssts_ssttem_publicuse_lg_geolssts_v2geolassets_assetitem_T_Id">
+        <attributeEditorContainer name="Öffentliche Nutzung" visibilityExpression="" columnCount="1" backgroundColor="#ffe0b2" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
+          <attributeEditorRelation name="publicuse_lg_glssts_vssts_ssttem_publicuse_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="one_to_one" label="Öffentliche Nutzung" relation="publicuse_lg_glssts_vssts_ssttem_publicuse_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="linking_relation_editor" forceSuppressFormPopup="0" showLabel="0">
             <editor_configuration type="Map">
               <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature"/>
               <Option name="one_to_one" type="bool" value="true"/>
@@ -642,10 +645,10 @@ def my_form_open(dialog, layer, feature):
           </attributeEditorRelation>
         </attributeEditorContainer>
       </attributeEditorContainer>
-      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Nationale Relevanz" columnCount="1" groupBox="1" showLabel="1">
+      <attributeEditorContainer name="Nationale Relevanz" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
         <attributeEditorField name="isnatrel" index="3" showLabel="1"/>
-        <attributeEditorContainer visibilityExpressionEnabled="1" visibilityExpression="&quot;isnatrel&quot;" name="Type(n)" columnCount="1" groupBox="1" showLabel="1">
-          <attributeEditorRelation forceSuppressFormPopup="0" name="typenatrel_lg_glssts_vssts_ssttem_typenatrel_lg_geolssts_v2geolassets_assetitem_T_Id" label="" relationWidgetTypeId="relation_editor" nmRelationId="typenatrel_typenatrel_natrelitem_T_Id" showLabel="0" relation="typenatrel_lg_glssts_vssts_ssttem_typenatrel_lg_geolssts_v2geolassets_assetitem_T_Id">
+        <attributeEditorContainer name="Type(n)" visibilityExpression="&quot;isnatrel&quot;" columnCount="1" visibilityExpressionEnabled="1" groupBox="1" showLabel="1">
+          <attributeEditorRelation name="typenatrel_lg_glssts_vssts_ssttem_typenatrel_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="typenatrel_typenatrel_natrelitem_T_Id" label="" relation="typenatrel_lg_glssts_vssts_ssttem_typenatrel_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="0">
             <editor_configuration type="Map">
               <Option name="buttons" type="QString" value="Link|Unlink"/>
               <Option name="show_first_feature" type="bool" value="true"/>
@@ -654,20 +657,20 @@ def my_form_open(dialog, layer, feature):
         </attributeEditorContainer>
       </attributeEditorContainer>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Lage (Geometrien)" columnCount="1" groupBox="0" showLabel="1">
-      <attributeEditorRelation forceSuppressFormPopup="0" name="studylocation_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Study Location" relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="1" relation="studylocation_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
+    <attributeEditorContainer name="Lage (Geometrien)" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorRelation name="studylocation_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="" label="Study Location" relation="studylocation_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="1">
         <editor_configuration type="Map">
           <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature|ZoomToChildFeature"/>
           <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
-      <attributeEditorRelation forceSuppressFormPopup="0" name="studytrace_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Study Trace" relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="1" relation="studytrace_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
+      <attributeEditorRelation name="studytrace_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="" label="Study Trace" relation="studytrace_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="1">
         <editor_configuration type="Map">
           <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature|ZoomToChildFeature"/>
           <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
-      <attributeEditorRelation forceSuppressFormPopup="0" name="studyarea_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Study Area" relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="1" relation="studyarea_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
+      <attributeEditorRelation name="studyarea_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="" label="Study Area" relation="studyarea_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="1">
         <editor_configuration type="Map">
           <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature|ZoomToChildFeature"/>
           <Option name="show_first_feature" type="bool" value="true"/>
@@ -675,34 +678,34 @@ def my_form_open(dialog, layer, feature):
       </attributeEditorRelation>
       <attributeEditorField name="municipality" index="5" showLabel="1"/>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Kontakte" columnCount="1" groupBox="0" showLabel="1">
-      <attributeEditorRelation forceSuppressFormPopup="0" name="assetitem_contact_author_authoredassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Autor" relationWidgetTypeId="relation_editor" nmRelationId="assetitem_contact_author_author_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" showLabel="1" relation="assetitem_contact_author_authoredassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
+    <attributeEditorContainer name="Kontakte" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorRelation name="assetitem_contact_author_authoredassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="assetitem_contact_author_author_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" label="Autor" relation="assetitem_contact_author_authoredassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="1">
         <editor_configuration type="Map">
           <Option name="buttons" type="QString" value="Link|Unlink|AddChildFeature|DeleteChildFeature"/>
           <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
-      <attributeEditorRelation forceSuppressFormPopup="0" name="assetitem_contact_supplier_suppliedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Supplier" relationWidgetTypeId="relation_editor" nmRelationId="assetitem_contact_supplier_supplier_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" showLabel="1" relation="assetitem_contact_supplier_suppliedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
+      <attributeEditorRelation name="assetitem_contact_supplier_suppliedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="assetitem_contact_supplier_supplier_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" label="Supplier" relation="assetitem_contact_supplier_suppliedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="1">
         <editor_configuration type="Map">
           <Option name="buttons" type="QString" value="Link|Unlink|AddChildFeature|DeleteChildFeature"/>
           <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
-      <attributeEditorRelation forceSuppressFormPopup="0" name="assetitem_contact_initiator_initiatedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Initiator" relationWidgetTypeId="relation_editor" nmRelationId="assetitem_contact_initiator_initiator_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" showLabel="1" relation="assetitem_contact_initiator_initiatedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
+      <attributeEditorRelation name="assetitem_contact_initiator_initiatedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="assetitem_contact_initiator_initiator_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" label="Initiator" relation="assetitem_contact_initiator_initiatedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="1">
         <editor_configuration type="Map">
           <Option name="buttons" type="QString" value="Link|Unlink|AddChildFeature|DeleteChildFeature"/>
           <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Pfade *" columnCount="2" groupBox="0" showLabel="1">
-      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Ablagen" columnCount="1" groupBox="1" showLabel="1">
+    <attributeEditorContainer name="Pfade *" visibilityExpression="" columnCount="2" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorContainer name="Ablagen" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
         <attributeEditorField name="url" index="6" showLabel="1"/>
         <attributeEditorField name="relativepath" index="7" showLabel="1"/>
         <attributeEditorField name="locationanalog" index="8" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Rechtliche Dokumente" columnCount="1" groupBox="1" showLabel="1">
-        <attributeEditorRelation forceSuppressFormPopup="0" name="legaldoc_lg_glssts_vssts_ssttem_legaldoc_lg_geolssts_v2geolassets_assetitem_T_Id" label="" relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="0" relation="legaldoc_lg_glssts_vssts_ssttem_legaldoc_lg_geolssts_v2geolassets_assetitem_T_Id">
+      <attributeEditorContainer name="Rechtliche Dokumente" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
+        <attributeEditorRelation name="legaldoc_lg_glssts_vssts_ssttem_legaldoc_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="" label="" relation="legaldoc_lg_glssts_vssts_ssttem_legaldoc_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="0">
           <editor_configuration type="Map">
             <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature"/>
             <Option name="show_first_feature" type="bool" value="true"/>
@@ -710,39 +713,39 @@ def my_form_open(dialog, layer, feature):
         </attributeEditorRelation>
       </attributeEditorContainer>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Publikationen" columnCount="1" groupBox="0" showLabel="1">
-      <attributeEditorRelation forceSuppressFormPopup="0" name="assetitem_publication_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="" relationWidgetTypeId="relation_editor" nmRelationId="assetitem_publication_publication_publication_T_Id" showLabel="0" relation="assetitem_publication_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
+    <attributeEditorContainer name="Publikationen" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorRelation name="assetitem_publication_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="assetitem_publication_publication_publication_T_Id" label="" relation="assetitem_publication_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="0">
         <editor_configuration type="Map">
           <Option name="buttons" type="QString" value="Link|Unlink|AddChildFeature|DeleteChildFeature|ZoomToChildFeature"/>
           <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Referenzierte Assets" columnCount="1" groupBox="0" showLabel="1">
-      <attributeEditorRelation forceSuppressFormPopup="0" name="assetitemx_assetitemy_assetitemy_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Verlinkte Assets " relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="1" relation="assetitemx_assetitemy_assetitemy_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
+    <attributeEditorContainer name="Referenzierte Assets" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorRelation name="assetitemx_assetitemy_assetitemy_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="" label="Verlinkte Assets " relation="assetitemx_assetitemy_assetitemy_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="1">
         <editor_configuration type="Map">
           <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature"/>
           <Option name="show_first_feature" type="bool" value="false"/>
         </editor_configuration>
       </attributeEditorRelation>
-      <attributeEditorRelation forceSuppressFormPopup="0" name="assetitemx_assetitemy_assetitemx_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Assets, die auf diesen Asset verlinken" relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="1" relation="assetitemx_assetitemy_assetitemx_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
+      <attributeEditorRelation name="assetitemx_assetitemy_assetitemx_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="" label="Assets, die auf diesen Asset verlinken" relation="assetitemx_assetitemy_assetitemx_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="1">
         <editor_configuration type="Map">
           <Option name="buttons" type="QString" value="NoButton"/>
           <Option name="show_first_feature" type="bool" value="false"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Interne Projekte" columnCount="1" groupBox="0" showLabel="1">
-      <attributeEditorRelation forceSuppressFormPopup="0" name="assetitem_usedby_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="" relationWidgetTypeId="relation_editor" nmRelationId="assetitem_usedby_usedby_internalproject_T_Id" showLabel="0" relation="assetitem_usedby_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
+    <attributeEditorContainer name="Interne Projekte" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorRelation name="assetitem_usedby_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="assetitem_usedby_usedby_internalproject_T_Id" label="" relation="assetitem_usedby_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="0">
         <editor_configuration type="Map">
           <Option name="buttons" type="QString" value="Link|Unlink|SaveChildEdits|AddChildFeature|DeleteChildFeature"/>
           <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Info KI" columnCount="1" groupBox="0" showLabel="1">
+    <attributeEditorContainer name="Info KI" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
       <attributeEditorField name="textbody" index="11" showLabel="1"/>
-      <attributeEditorRelation forceSuppressFormPopup="0" name="autocat_lg_glssts_vssts_ssttem_autocatlabel_lg_geolssts_v2geolassets_assetitem_T_Id" label="Automatisch zugewiesene Klasse" relationWidgetTypeId="linking_relation_editor" nmRelationId="one_to_one" showLabel="1" relation="autocat_lg_glssts_vssts_ssttem_autocatlabel_lg_geolssts_v2geolassets_assetitem_T_Id">
+      <attributeEditorRelation name="autocat_lg_glssts_vssts_ssttem_autocatlabel_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="one_to_one" label="Automatisch zugewiesene Klasse" relation="autocat_lg_glssts_vssts_ssttem_autocatlabel_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="linking_relation_editor" forceSuppressFormPopup="0" showLabel="1">
         <editor_configuration type="Map">
           <Option name="buttons" type="QString" value="AllButtons"/>
           <Option name="one_to_one" type="bool" value="true"/>
@@ -750,19 +753,19 @@ def my_form_open(dialog, layer, feature):
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="InfoGeol" columnCount="1" groupBox="0" showLabel="1">
+    <attributeEditorContainer name="InfoGeol" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
       <attributeEditorField name="infogeoldata" index="14" showLabel="1"/>
       <attributeEditorField name="infogeolcontactdata" index="15" showLabel="1"/>
       <attributeEditorField name="infogeolauxdata" index="16" showLabel="1"/>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Administration *" columnCount="2" groupBox="0" showLabel="1">
-      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Bearbeitung" columnCount="1" groupBox="1" showLabel="1">
+    <attributeEditorContainer name="Administration *" visibilityExpression="" columnCount="2" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorContainer name="Bearbeitung" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
         <attributeEditorField name="datereceipt" index="4" showLabel="1"/>
         <attributeEditorField name="processor" index="9" showLabel="1"/>
         <attributeEditorField name="datelastprocessed" index="10" showLabel="1"/>
       </attributeEditorContainer>
-      <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" backgroundColor="#ffe0b2" name="Bearbeitungsstatus (mindestens ein Eintrag)" columnCount="1" groupBox="1" showLabel="1">
-        <attributeEditorRelation forceSuppressFormPopup="0" name="statuswork_lg_glssts_vssts_ssttem_statuswork_lg_geolssts_v2geolassets_assetitem_T_Id" label="" relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="0" relation="statuswork_lg_glssts_vssts_ssttem_statuswork_lg_geolssts_v2geolassets_assetitem_T_Id">
+      <attributeEditorContainer name="Bearbeitungsstatus (mindestens ein Eintrag)" visibilityExpression="" columnCount="1" backgroundColor="#ffe0b2" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
+        <attributeEditorRelation name="statuswork_lg_glssts_vssts_ssttem_statuswork_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="" label="" relation="statuswork_lg_glssts_vssts_ssttem_statuswork_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="0">
           <editor_configuration type="Map">
             <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature"/>
             <Option name="show_first_feature" type="bool" value="true"/>
@@ -770,15 +773,15 @@ def my_form_open(dialog, layer, feature):
         </attributeEditorRelation>
       </attributeEditorContainer>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpressionEnabled="1" visibilityExpression="NOT isextract" name="Teilassets" columnCount="1" groupBox="0" showLabel="1">
+    <attributeEditorContainer name="Teilassets" visibilityExpression="NOT isextract" columnCount="1" visibilityExpressionEnabled="1" groupBox="0" showLabel="1">
       <attributeEditorField name="Teilasset Info" index="29" showLabel="0"/>
-      <attributeEditorRelation forceSuppressFormPopup="0" name="lg_geolssts_v2geolassets_assetitem_assetitemmain_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" label="Verknüpfte Teilassets" relationWidgetTypeId="relation_editor" nmRelationId="" showLabel="1" relation="lg_geolssts_v2geolassets_assetitem_assetitemmain_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id">
+      <attributeEditorRelation name="lg_geolssts_v2geolassets_assetitem_assetitemmain_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="" label="Verknüpfte Teilassets" relation="lg_geolssts_v2geolassets_assetitem_assetitemmain_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="1">
         <editor_configuration type="Map">
           <Option name="buttons" type="QString" value="Link|Unlink|AddChildFeature|DeleteChildFeature"/>
           <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
-      <attributeEditorRelation forceSuppressFormPopup="0" name="assetkindref_lg_glssts_vssts_ssttem_assetcomposition_lg_geolssts_v2geolassets_assetitem_T_Id" label="Arten der Teilassets" relationWidgetTypeId="relation_editor" nmRelationId="assetkindref_areference_assetkinditem_T_Id" showLabel="1" relation="assetkindref_lg_glssts_vssts_ssttem_assetcomposition_lg_geolssts_v2geolassets_assetitem_T_Id">
+      <attributeEditorRelation name="assetkindref_lg_glssts_vssts_ssttem_assetcomposition_lg_geolssts_v2geolassets_assetitem_T_Id" nmRelationId="assetkindref_areference_assetkinditem_T_Id" label="Arten der Teilassets" relation="assetkindref_lg_glssts_vssts_ssttem_assetcomposition_lg_geolssts_v2geolassets_assetitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="1">
         <editor_configuration type="Map">
           <Option name="buttons" type="QString" value="Link|Unlink"/>
           <Option name="show_first_feature" type="bool" value="true"/>
@@ -853,37 +856,37 @@ def my_form_open(dialog, layer, feature):
     <field name="url" labelOnTop="0"/>
   </labelOnTop>
   <reuseLastValue>
-    <field name="T_Id" reuseLastValue="0"/>
-    <field name="T_Ili_Tid" reuseLastValue="0"/>
-    <field name="T_basket" reuseLastValue="0"/>
-    <field name="Teilasset Info" reuseLastValue="0"/>
-    <field name="adescription" reuseLastValue="0"/>
-    <field name="aformat" reuseLastValue="0"/>
-    <field name="akind" reuseLastValue="0"/>
-    <field name="alanguage" reuseLastValue="0"/>
-    <field name="assetitemmain_assetitem" reuseLastValue="0"/>
-    <field name="assetitemmain_lg_geolssts_v2geolassets_assetitem" reuseLastValue="0"/>
-    <field name="authorbiblio" reuseLastValue="0"/>
-    <field name="datecreation" reuseLastValue="0"/>
-    <field name="datelastprocessed" reuseLastValue="0"/>
-    <field name="datereceipt" reuseLastValue="0"/>
-    <field name="formatcomposition" reuseLastValue="0"/>
-    <field name="idsgs" reuseLastValue="0"/>
-    <field name="infogeolauxdata" reuseLastValue="0"/>
-    <field name="infogeolcontactdata" reuseLastValue="0"/>
-    <field name="infogeoldata" reuseLastValue="0"/>
-    <field name="isextract" reuseLastValue="0"/>
-    <field name="isnatrel" reuseLastValue="0"/>
-    <field name="locationanalog" reuseLastValue="0"/>
-    <field name="municipality" reuseLastValue="0"/>
-    <field name="processor" reuseLastValue="0"/>
-    <field name="relativepath" reuseLastValue="0"/>
-    <field name="remark" reuseLastValue="0"/>
-    <field name="sourceproject" reuseLastValue="0"/>
-    <field name="textbody" reuseLastValue="0"/>
-    <field name="titleoriginal" reuseLastValue="0"/>
-    <field name="titlepublic" reuseLastValue="0"/>
-    <field name="url" reuseLastValue="0"/>
+    <field reuseLastValue="0" name="T_Id"/>
+    <field reuseLastValue="0" name="T_Ili_Tid"/>
+    <field reuseLastValue="0" name="T_basket"/>
+    <field reuseLastValue="0" name="Teilasset Info"/>
+    <field reuseLastValue="0" name="adescription"/>
+    <field reuseLastValue="0" name="aformat"/>
+    <field reuseLastValue="0" name="akind"/>
+    <field reuseLastValue="0" name="alanguage"/>
+    <field reuseLastValue="0" name="assetitemmain_assetitem"/>
+    <field reuseLastValue="0" name="assetitemmain_lg_geolssts_v2geolassets_assetitem"/>
+    <field reuseLastValue="0" name="authorbiblio"/>
+    <field reuseLastValue="0" name="datecreation"/>
+    <field reuseLastValue="0" name="datelastprocessed"/>
+    <field reuseLastValue="0" name="datereceipt"/>
+    <field reuseLastValue="0" name="formatcomposition"/>
+    <field reuseLastValue="0" name="idsgs"/>
+    <field reuseLastValue="0" name="infogeolauxdata"/>
+    <field reuseLastValue="0" name="infogeolcontactdata"/>
+    <field reuseLastValue="0" name="infogeoldata"/>
+    <field reuseLastValue="0" name="isextract"/>
+    <field reuseLastValue="0" name="isnatrel"/>
+    <field reuseLastValue="0" name="locationanalog"/>
+    <field reuseLastValue="0" name="municipality"/>
+    <field reuseLastValue="0" name="processor"/>
+    <field reuseLastValue="0" name="relativepath"/>
+    <field reuseLastValue="0" name="remark"/>
+    <field reuseLastValue="0" name="sourceproject"/>
+    <field reuseLastValue="0" name="textbody"/>
+    <field reuseLastValue="0" name="titleoriginal"/>
+    <field reuseLastValue="0" name="titlepublic"/>
+    <field reuseLastValue="0" name="url"/>
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets>

--- a/lg_geolassets_v2/layerstyle/assetitem_contact_author.qml
+++ b/lg_geolassets_v2/layerstyle/assetitem_contact_author.qml
@@ -1,62 +1,224 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="Fields|CustomProperties" version="3.25.0-Master">
+<qgis styleCategories="LayerConfiguration|Fields|Forms|CustomProperties" readOnly="0" version="3.24.3-Tisler">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
   <customproperties>
     <Option type="Map">
-      <Option value="copy" type="QString" name="QFieldSync/action"/>
-      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
-      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
-      <Option type="List" name="dualview/previewExpressions">
-        <Option value="&quot;T_Id&quot;" type="QString"/>
+      <Option name="QFieldSync/action" type="QString" value="copy"/>
+      <Option name="QFieldSync/cloud_action" type="QString" value="offline"/>
+      <Option name="QFieldSync/photo_naming" type="QString" value="{}"/>
+      <Option name="dualview/previewExpressions" type="List">
+        <Option type="QString" value="attribute(get_feature('AssetItem', 'T_Id', &quot;authoredassetitem_lg_geolssts_v2geolassets_assetitem&quot;),'titleoriginal')"/>
+        <Option type="QString" value="&quot;T_Id&quot;"/>
+        <Option type="QString" value="attribute(get_feature('AssetItem', 'T_Id', &quot;authoredassetitem_lg_geolssts_v2geolassets_assetitem&quot;),'titleoriginal')"/>
       </Option>
-      <Option value="0" type="int" name="embeddedWidgets/count"/>
-      <Option type="StringList" name="variableNames">
-        <Option value="interlis_topic" type="QString"/>
+      <Option name="embeddedWidgets/count" type="int" value="0"/>
+      <Option name="variableNames" type="StringList">
+        <Option type="QString" value="interlis_topic"/>
       </Option>
-      <Option type="StringList" name="variableValues">
-        <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
+      <Option name="variableValues" type="StringList">
+        <Option type="QString" value="LG_GeolAssets_V2.GeolAssets"/>
       </Option>
     </Option>
   </customproperties>
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id"/>
-    <field configurationFlags="None" name="T_basket"/>
-    <field configurationFlags="None" name="authoredassetitem_assetitem"/>
-    <field configurationFlags="None" name="authoredassetitem_lg_geolssts_v2geolassets_assetitem"/>
-    <field configurationFlags="None" name="author_contact"/>
-    <field configurationFlags="None" name="author_lg_geolssts_v2geolassets_contact"/>
+    <field name="T_Id" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="T_basket" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_9a69fa2e_5fe3_4394_b675_9254fd08b57b"/>
+            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_contact_author_T_basket_T_ILI2DB_BASKET_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="authoredassetitem_assetitem" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=assetitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetItem_881b3b01_524b_4b04_8156_c2e457353572"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_contact_author_authoredassetitem_assetitem_assetitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="authoredassetitem_lg_geolssts_v2geolassets_assetitem" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_contact_author_authoredassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="author_contact" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=contact"/>
+            <Option name="ReferencedLayerId" type="QString" value="Contact_c10e01b5_6f3e_4b43_bfd7_998c10d7d4ba"/>
+            <Option name="ReferencedLayerName" type="QString" value="Contact"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_contact_author_author_contact_contact_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="author_lg_geolssts_v2geolassets_contact" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_contact"/>
+            <Option name="ReferencedLayerId" type="QString" value="Contact_c7ed9e21_34ff_45ef_9ca6_0556cc627cd5"/>
+            <Option name="ReferencedLayerName" type="QString" value="Contact"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_contact_author_author_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="T_Id" index="0" name=""/>
-    <alias field="T_basket" index="1" name=""/>
-    <alias field="authoredassetitem_assetitem" index="2" name="AuthoredAssetItem"/>
-    <alias field="authoredassetitem_lg_geolssts_v2geolassets_assetitem" index="3" name="AuthoredAssetItem  LG"/>
-    <alias field="author_contact" index="4" name="Author"/>
-    <alias field="author_lg_geolssts_v2geolassets_contact" index="5" name="Author  LG"/>
+    <alias name="" index="0" field="T_Id"/>
+    <alias name="" index="1" field="T_basket"/>
+    <alias name="AuthoredAssetItem" index="2" field="authoredassetitem_assetitem"/>
+    <alias name="Asset Item" index="3" field="authoredassetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <alias name="Author" index="4" field="author_contact"/>
+    <alias name="Author  LG" index="5" field="author_lg_geolssts_v2geolassets_contact"/>
   </aliases>
   <defaults>
-    <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
-    <default field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets" applyOnUpdate="0"/>
-    <default field="authoredassetitem_assetitem" expression="" applyOnUpdate="0"/>
-    <default field="authoredassetitem_lg_geolssts_v2geolassets_assetitem" expression="" applyOnUpdate="0"/>
-    <default field="author_contact" expression="" applyOnUpdate="0"/>
-    <default field="author_lg_geolssts_v2geolassets_contact" expression="" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
+    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
+    <default applyOnUpdate="0" field="authoredassetitem_assetitem" expression=""/>
+    <default applyOnUpdate="0" field="authoredassetitem_lg_geolssts_v2geolassets_assetitem" expression=""/>
+    <default applyOnUpdate="0" field="author_contact" expression=""/>
+    <default applyOnUpdate="0" field="author_lg_geolssts_v2geolassets_contact" expression=""/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" notnull_strength="1" field="T_Id" exp_strength="0" constraints="3"/>
-    <constraint unique_strength="0" notnull_strength="1" field="T_basket" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="authoredassetitem_assetitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="authoredassetitem_lg_geolssts_v2geolassets_assetitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="author_contact" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="author_lg_geolssts_v2geolassets_contact" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="authoredassetitem_assetitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="authoredassetitem_lg_geolssts_v2geolassets_assetitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="author_contact" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="author_lg_geolssts_v2geolassets_contact" notnull_strength="0" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="T_Id" desc="" exp=""/>
-    <constraint field="T_basket" desc="" exp=""/>
-    <constraint field="authoredassetitem_assetitem" desc="" exp=""/>
-    <constraint field="authoredassetitem_lg_geolssts_v2geolassets_assetitem" desc="" exp=""/>
-    <constraint field="author_contact" desc="" exp=""/>
-    <constraint field="author_lg_geolssts_v2geolassets_contact" desc="" exp=""/>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="authoredassetitem_assetitem" desc=""/>
+    <constraint exp="" field="authoredassetitem_lg_geolssts_v2geolassets_assetitem" desc=""/>
+    <constraint exp="" field="author_contact" desc=""/>
+    <constraint exp="" field="author_lg_geolssts_v2geolassets_contact" desc=""/>
   </constraintExpressions>
   <expressionfields/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorField name="authoredassetitem_lg_geolssts_v2geolassets_assetitem" index="3" showLabel="1"/>
+  </attributeEditorForm>
+  <editable>
+    <field name="T_Id" editable="1"/>
+    <field name="T_basket" editable="1"/>
+    <field name="author_contact" editable="1"/>
+    <field name="author_lg_geolssts_v2geolassets_contact" editable="1"/>
+    <field name="authoredassetitem_assetitem" editable="1"/>
+    <field name="authoredassetitem_lg_geolssts_v2geolassets_assetitem" editable="0"/>
+  </editable>
+  <labelOnTop>
+    <field name="T_Id" labelOnTop="0"/>
+    <field name="T_basket" labelOnTop="0"/>
+    <field name="author_contact" labelOnTop="0"/>
+    <field name="author_lg_geolssts_v2geolassets_contact" labelOnTop="0"/>
+    <field name="authoredassetitem_assetitem" labelOnTop="0"/>
+    <field name="authoredassetitem_lg_geolssts_v2geolassets_assetitem" labelOnTop="0"/>
+  </labelOnTop>
+  <reuseLastValue>
+    <field reuseLastValue="0" name="T_Id"/>
+    <field reuseLastValue="0" name="T_basket"/>
+    <field reuseLastValue="0" name="author_contact"/>
+    <field reuseLastValue="0" name="author_lg_geolssts_v2geolassets_contact"/>
+    <field reuseLastValue="0" name="authoredassetitem_assetitem"/>
+    <field reuseLastValue="0" name="authoredassetitem_lg_geolssts_v2geolassets_assetitem"/>
+  </reuseLastValue>
+  <dataDefinedFieldProperties/>
+  <widgets/>
+  <previewExpression>attribute(get_feature('AssetItem', 'T_Id', "authoredassetitem_lg_geolssts_v2geolassets_assetitem"),'titleoriginal')</previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/layerstyle/assetitem_contact_author.qml
+++ b/lg_geolassets_v2/layerstyle/assetitem_contact_author.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="LayerConfiguration|Fields|Forms|CustomProperties" readOnly="0" version="3.24.3-Tisler">
+<qgis readOnly="0" version="3.22.11-Białowieża" styleCategories="LayerConfiguration|Fields|Forms|CustomProperties">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -8,155 +8,155 @@
   </flags>
   <customproperties>
     <Option type="Map">
-      <Option name="QFieldSync/action" type="QString" value="copy"/>
-      <Option name="QFieldSync/cloud_action" type="QString" value="offline"/>
-      <Option name="QFieldSync/photo_naming" type="QString" value="{}"/>
-      <Option name="dualview/previewExpressions" type="List">
-        <Option type="QString" value="attribute(get_feature('AssetItem', 'T_Id', &quot;authoredassetitem_lg_geolssts_v2geolassets_assetitem&quot;),'titleoriginal')"/>
-        <Option type="QString" value="&quot;T_Id&quot;"/>
-        <Option type="QString" value="attribute(get_feature('AssetItem', 'T_Id', &quot;authoredassetitem_lg_geolssts_v2geolassets_assetitem&quot;),'titleoriginal')"/>
+      <Option value="copy" type="QString" name="QFieldSync/action"/>
+      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
+      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
+      <Option type="List" name="dualview/previewExpressions">
+        <Option value="attribute(get_feature('AssetItem', 'T_Id', &quot;authoredassetitem_lg_geolssts_v2geolassets_assetitem&quot;),'titleoriginal')" type="QString"/>
+        <Option value="&quot;T_Id&quot;" type="QString"/>
+        <Option value="attribute(get_feature('AssetItem', 'T_Id', &quot;authoredassetitem_lg_geolssts_v2geolassets_assetitem&quot;),'titleoriginal')" type="QString"/>
       </Option>
-      <Option name="embeddedWidgets/count" type="int" value="0"/>
-      <Option name="variableNames" type="StringList">
-        <Option type="QString" value="interlis_topic"/>
+      <Option value="0" type="int" name="embeddedWidgets/count"/>
+      <Option type="StringList" name="variableNames">
+        <Option value="interlis_topic" type="QString"/>
       </Option>
-      <Option name="variableValues" type="StringList">
-        <Option type="QString" value="LG_GeolAssets_V2.GeolAssets"/>
+      <Option type="StringList" name="variableValues">
+        <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
       </Option>
     </Option>
   </customproperties>
   <fieldConfiguration>
-    <field name="T_Id" configurationFlags="None">
+    <field configurationFlags="None" name="T_Id">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="T_basket" configurationFlags="None">
+    <field configurationFlags="None" name="T_basket">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_9a69fa2e_5fe3_4394_b675_9254fd08b57b"/>
-            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_contact_author_T_basket_T_ILI2DB_BASKET_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="T_ILI2DB_BASKET_9a69fa2e_5fe3_4394_b675_9254fd08b57b" type="QString" name="ReferencedLayerId"/>
+            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_contact_author_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="authoredassetitem_assetitem" configurationFlags="None">
+    <field configurationFlags="None" name="authoredassetitem_assetitem">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=assetitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="AssetItem_881b3b01_524b_4b04_8156_c2e457353572"/>
-            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_contact_author_authoredassetitem_assetitem_assetitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=assetitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="AssetItem_881b3b01_524b_4b04_8156_c2e457353572" type="QString" name="ReferencedLayerId"/>
+            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_contact_author_authoredassetitem_assetitem_assetitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="authoredassetitem_lg_geolssts_v2geolassets_assetitem" configurationFlags="None">
+    <field configurationFlags="None" name="authoredassetitem_lg_geolssts_v2geolassets_assetitem">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
-            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_contact_author_authoredassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d" type="QString" name="ReferencedLayerId"/>
+            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_contact_author_authoredassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="author_contact" configurationFlags="None">
+    <field configurationFlags="None" name="author_contact">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=contact"/>
-            <Option name="ReferencedLayerId" type="QString" value="Contact_c10e01b5_6f3e_4b43_bfd7_998c10d7d4ba"/>
-            <Option name="ReferencedLayerName" type="QString" value="Contact"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_contact_author_author_contact_contact_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=contact" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="Contact_c10e01b5_6f3e_4b43_bfd7_998c10d7d4ba" type="QString" name="ReferencedLayerId"/>
+            <Option value="Contact" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_contact_author_author_contact_contact_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="author_lg_geolssts_v2geolassets_contact" configurationFlags="None">
+    <field configurationFlags="None" name="author_lg_geolssts_v2geolassets_contact">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_contact"/>
-            <Option name="ReferencedLayerId" type="QString" value="Contact_c7ed9e21_34ff_45ef_9ca6_0556cc627cd5"/>
-            <Option name="ReferencedLayerName" type="QString" value="Contact"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_contact_author_author_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_contact" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="Contact_c7ed9e21_34ff_45ef_9ca6_0556cc627cd5" type="QString" name="ReferencedLayerId"/>
+            <Option value="Contact" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_contact_author_author_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="T_Id"/>
-    <alias name="" index="1" field="T_basket"/>
-    <alias name="AuthoredAssetItem" index="2" field="authoredassetitem_assetitem"/>
-    <alias name="Asset Item" index="3" field="authoredassetitem_lg_geolssts_v2geolassets_assetitem"/>
-    <alias name="Author" index="4" field="author_contact"/>
-    <alias name="Author  LG" index="5" field="author_lg_geolssts_v2geolassets_contact"/>
+    <alias field="T_Id" index="0" name=""/>
+    <alias field="T_basket" index="1" name=""/>
+    <alias field="authoredassetitem_assetitem" index="2" name="AuthoredAssetItem"/>
+    <alias field="authoredassetitem_lg_geolssts_v2geolassets_assetitem" index="3" name="Asset Item"/>
+    <alias field="author_contact" index="4" name="Author"/>
+    <alias field="author_lg_geolssts_v2geolassets_contact" index="5" name="Author  LG"/>
   </aliases>
   <defaults>
-    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
-    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
-    <default applyOnUpdate="0" field="authoredassetitem_assetitem" expression=""/>
-    <default applyOnUpdate="0" field="authoredassetitem_lg_geolssts_v2geolassets_assetitem" expression=""/>
-    <default applyOnUpdate="0" field="author_contact" expression=""/>
-    <default applyOnUpdate="0" field="author_lg_geolssts_v2geolassets_contact" expression=""/>
+    <default expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" field="T_Id" applyOnUpdate="0"/>
+    <default expression="@default_basket_lg_geolassets_v2_geolassets" field="T_basket" applyOnUpdate="0"/>
+    <default expression="" field="authoredassetitem_assetitem" applyOnUpdate="0"/>
+    <default expression="" field="authoredassetitem_lg_geolssts_v2geolassets_assetitem" applyOnUpdate="0"/>
+    <default expression="" field="author_contact" applyOnUpdate="0"/>
+    <default expression="" field="author_lg_geolssts_v2geolassets_contact" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="authoredassetitem_assetitem" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="authoredassetitem_lg_geolssts_v2geolassets_assetitem" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="author_contact" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="author_lg_geolssts_v2geolassets_contact" notnull_strength="0" exp_strength="0"/>
+    <constraint field="T_Id" exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3"/>
+    <constraint field="T_basket" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint field="authoredassetitem_assetitem" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="authoredassetitem_lg_geolssts_v2geolassets_assetitem" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="author_contact" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="author_lg_geolssts_v2geolassets_contact" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="T_Id" desc=""/>
@@ -191,23 +191,23 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField name="authoredassetitem_lg_geolssts_v2geolassets_assetitem" index="3" showLabel="1"/>
+    <attributeEditorField index="3" showLabel="1" name="authoredassetitem_lg_geolssts_v2geolassets_assetitem"/>
   </attributeEditorForm>
   <editable>
-    <field name="T_Id" editable="1"/>
-    <field name="T_basket" editable="1"/>
-    <field name="author_contact" editable="1"/>
-    <field name="author_lg_geolssts_v2geolassets_contact" editable="1"/>
-    <field name="authoredassetitem_assetitem" editable="1"/>
-    <field name="authoredassetitem_lg_geolssts_v2geolassets_assetitem" editable="0"/>
+    <field editable="1" name="T_Id"/>
+    <field editable="1" name="T_basket"/>
+    <field editable="1" name="author_contact"/>
+    <field editable="1" name="author_lg_geolssts_v2geolassets_contact"/>
+    <field editable="1" name="authoredassetitem_assetitem"/>
+    <field editable="0" name="authoredassetitem_lg_geolssts_v2geolassets_assetitem"/>
   </editable>
   <labelOnTop>
-    <field name="T_Id" labelOnTop="0"/>
-    <field name="T_basket" labelOnTop="0"/>
-    <field name="author_contact" labelOnTop="0"/>
-    <field name="author_lg_geolssts_v2geolassets_contact" labelOnTop="0"/>
-    <field name="authoredassetitem_assetitem" labelOnTop="0"/>
-    <field name="authoredassetitem_lg_geolssts_v2geolassets_assetitem" labelOnTop="0"/>
+    <field labelOnTop="0" name="T_Id"/>
+    <field labelOnTop="0" name="T_basket"/>
+    <field labelOnTop="0" name="author_contact"/>
+    <field labelOnTop="0" name="author_lg_geolssts_v2geolassets_contact"/>
+    <field labelOnTop="0" name="authoredassetitem_assetitem"/>
+    <field labelOnTop="0" name="authoredassetitem_lg_geolssts_v2geolassets_assetitem"/>
   </labelOnTop>
   <reuseLastValue>
     <field reuseLastValue="0" name="T_Id"/>
@@ -219,6 +219,6 @@ def my_form_open(dialog, layer, feature):
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>
-  <previewExpression>attribute(get_feature('AssetItem', 'T_Id', "authoredassetitem_lg_geolssts_v2geolassets_assetitem"),'titleoriginal')</previewExpression>
+  <previewExpression>coalesce( attribute(get_feature('AssetItem', 'T_Id', "authoredassetitem_lg_geolssts_v2geolassets_assetitem"),'titlepublic'),'Kein Öffentlicher Titel vorhanden' )</previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/layerstyle/assetitem_contact_initiator.qml
+++ b/lg_geolassets_v2/layerstyle/assetitem_contact_initiator.qml
@@ -1,62 +1,224 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="Fields|CustomProperties" version="3.25.0-Master">
+<qgis styleCategories="LayerConfiguration|Fields|Forms|CustomProperties" readOnly="0" version="3.24.3-Tisler">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
   <customproperties>
     <Option type="Map">
-      <Option value="copy" type="QString" name="QFieldSync/action"/>
-      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
-      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
-      <Option type="List" name="dualview/previewExpressions">
-        <Option value="&quot;T_Id&quot;" type="QString"/>
+      <Option name="QFieldSync/action" type="QString" value="copy"/>
+      <Option name="QFieldSync/cloud_action" type="QString" value="offline"/>
+      <Option name="QFieldSync/photo_naming" type="QString" value="{}"/>
+      <Option name="dualview/previewExpressions" type="List">
+        <Option type="QString" value="attribute(get_feature('AssetItem', 'T_Id',  &quot;initiatedassetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'titleoriginal')"/>
+        <Option type="QString" value="&quot;T_Id&quot;"/>
+        <Option type="QString" value="attribute(get_feature('AssetItem', 'T_Id', &quot;authoredassetitem_lg_geolssts_v2geolassets_assetitem&quot;),'titleoriginal')"/>
       </Option>
-      <Option value="0" type="int" name="embeddedWidgets/count"/>
-      <Option type="StringList" name="variableNames">
-        <Option value="interlis_topic" type="QString"/>
+      <Option name="embeddedWidgets/count" type="int" value="0"/>
+      <Option name="variableNames" type="StringList">
+        <Option type="QString" value="interlis_topic"/>
       </Option>
-      <Option type="StringList" name="variableValues">
-        <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
+      <Option name="variableValues" type="StringList">
+        <Option type="QString" value="LG_GeolAssets_V2.GeolAssets"/>
       </Option>
     </Option>
   </customproperties>
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id"/>
-    <field configurationFlags="None" name="T_basket"/>
-    <field configurationFlags="None" name="initiatedassetitem_assetitem"/>
-    <field configurationFlags="None" name="initiatedassetitem_lg_geolssts_v2geolassets_assetitem"/>
-    <field configurationFlags="None" name="initiator_contact"/>
-    <field configurationFlags="None" name="initiator_lg_geolssts_v2geolassets_contact"/>
+    <field name="T_Id" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="T_basket" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_9a69fa2e_5fe3_4394_b675_9254fd08b57b"/>
+            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_contact_initiator_T_basket_T_ILI2DB_BASKET_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="initiatedassetitem_assetitem" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=assetitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetItem_881b3b01_524b_4b04_8156_c2e457353572"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_contact_initiator_initiatedassetitem_assetitem_assetitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_contact_initiator_initiatedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="initiator_contact" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=contact"/>
+            <Option name="ReferencedLayerId" type="QString" value="Contact_c10e01b5_6f3e_4b43_bfd7_998c10d7d4ba"/>
+            <Option name="ReferencedLayerName" type="QString" value="Contact"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_contact_initiator_initiator_contact_contact_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="initiator_lg_geolssts_v2geolassets_contact" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_contact"/>
+            <Option name="ReferencedLayerId" type="QString" value="Contact_c7ed9e21_34ff_45ef_9ca6_0556cc627cd5"/>
+            <Option name="ReferencedLayerName" type="QString" value="Contact"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_contact_initiator_initiator_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="T_Id" index="0" name=""/>
-    <alias field="T_basket" index="1" name=""/>
-    <alias field="initiatedassetitem_assetitem" index="2" name="InitiatedAssetItem"/>
-    <alias field="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" index="3" name="InitiatedAssetItem  LG"/>
-    <alias field="initiator_contact" index="4" name="Initiator"/>
-    <alias field="initiator_lg_geolssts_v2geolassets_contact" index="5" name="Initiator  LG"/>
+    <alias name="" index="0" field="T_Id"/>
+    <alias name="" index="1" field="T_basket"/>
+    <alias name="InitiatedAssetItem" index="2" field="initiatedassetitem_assetitem"/>
+    <alias name="Asset Item" index="3" field="initiatedassetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <alias name="Initiator" index="4" field="initiator_contact"/>
+    <alias name="Initiator  LG" index="5" field="initiator_lg_geolssts_v2geolassets_contact"/>
   </aliases>
   <defaults>
-    <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
-    <default field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets" applyOnUpdate="0"/>
-    <default field="initiatedassetitem_assetitem" expression="" applyOnUpdate="0"/>
-    <default field="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" expression="" applyOnUpdate="0"/>
-    <default field="initiator_contact" expression="" applyOnUpdate="0"/>
-    <default field="initiator_lg_geolssts_v2geolassets_contact" expression="" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
+    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
+    <default applyOnUpdate="0" field="initiatedassetitem_assetitem" expression=""/>
+    <default applyOnUpdate="0" field="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" expression=""/>
+    <default applyOnUpdate="0" field="initiator_contact" expression=""/>
+    <default applyOnUpdate="0" field="initiator_lg_geolssts_v2geolassets_contact" expression=""/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" notnull_strength="1" field="T_Id" exp_strength="0" constraints="3"/>
-    <constraint unique_strength="0" notnull_strength="1" field="T_basket" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="initiatedassetitem_assetitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="initiator_contact" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="initiator_lg_geolssts_v2geolassets_contact" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="initiatedassetitem_assetitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="initiator_contact" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="initiator_lg_geolssts_v2geolassets_contact" notnull_strength="0" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="T_Id" desc="" exp=""/>
-    <constraint field="T_basket" desc="" exp=""/>
-    <constraint field="initiatedassetitem_assetitem" desc="" exp=""/>
-    <constraint field="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" desc="" exp=""/>
-    <constraint field="initiator_contact" desc="" exp=""/>
-    <constraint field="initiator_lg_geolssts_v2geolassets_contact" desc="" exp=""/>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="initiatedassetitem_assetitem" desc=""/>
+    <constraint exp="" field="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" desc=""/>
+    <constraint exp="" field="initiator_contact" desc=""/>
+    <constraint exp="" field="initiator_lg_geolssts_v2geolassets_contact" desc=""/>
   </constraintExpressions>
   <expressionfields/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorField name="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" index="3" showLabel="1"/>
+  </attributeEditorForm>
+  <editable>
+    <field name="T_Id" editable="1"/>
+    <field name="T_basket" editable="1"/>
+    <field name="initiatedassetitem_assetitem" editable="1"/>
+    <field name="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" editable="0"/>
+    <field name="initiator_contact" editable="1"/>
+    <field name="initiator_lg_geolssts_v2geolassets_contact" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="T_Id" labelOnTop="0"/>
+    <field name="T_basket" labelOnTop="0"/>
+    <field name="initiatedassetitem_assetitem" labelOnTop="0"/>
+    <field name="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" labelOnTop="0"/>
+    <field name="initiator_contact" labelOnTop="0"/>
+    <field name="initiator_lg_geolssts_v2geolassets_contact" labelOnTop="0"/>
+  </labelOnTop>
+  <reuseLastValue>
+    <field reuseLastValue="0" name="T_Id"/>
+    <field reuseLastValue="0" name="T_basket"/>
+    <field reuseLastValue="0" name="initiatedassetitem_assetitem"/>
+    <field reuseLastValue="0" name="initiatedassetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <field reuseLastValue="0" name="initiator_contact"/>
+    <field reuseLastValue="0" name="initiator_lg_geolssts_v2geolassets_contact"/>
+  </reuseLastValue>
+  <dataDefinedFieldProperties/>
+  <widgets/>
+  <previewExpression>attribute(get_feature('AssetItem', 'T_Id',  "initiatedassetitem_lg_geolssts_v2geolassets_assetitem" ),'titleoriginal')</previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/layerstyle/assetitem_contact_initiator.qml
+++ b/lg_geolassets_v2/layerstyle/assetitem_contact_initiator.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="LayerConfiguration|Fields|Forms|CustomProperties" readOnly="0" version="3.24.3-Tisler">
+<qgis readOnly="0" version="3.22.11-Białowieża" styleCategories="LayerConfiguration|Fields|Forms|CustomProperties">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -8,155 +8,155 @@
   </flags>
   <customproperties>
     <Option type="Map">
-      <Option name="QFieldSync/action" type="QString" value="copy"/>
-      <Option name="QFieldSync/cloud_action" type="QString" value="offline"/>
-      <Option name="QFieldSync/photo_naming" type="QString" value="{}"/>
-      <Option name="dualview/previewExpressions" type="List">
-        <Option type="QString" value="attribute(get_feature('AssetItem', 'T_Id',  &quot;initiatedassetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'titleoriginal')"/>
-        <Option type="QString" value="&quot;T_Id&quot;"/>
-        <Option type="QString" value="attribute(get_feature('AssetItem', 'T_Id', &quot;authoredassetitem_lg_geolssts_v2geolassets_assetitem&quot;),'titleoriginal')"/>
+      <Option value="copy" type="QString" name="QFieldSync/action"/>
+      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
+      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
+      <Option type="List" name="dualview/previewExpressions">
+        <Option value="attribute(get_feature('AssetItem', 'T_Id',  &quot;initiatedassetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'titleoriginal')" type="QString"/>
+        <Option value="&quot;T_Id&quot;" type="QString"/>
+        <Option value="attribute(get_feature('AssetItem', 'T_Id', &quot;authoredassetitem_lg_geolssts_v2geolassets_assetitem&quot;),'titleoriginal')" type="QString"/>
       </Option>
-      <Option name="embeddedWidgets/count" type="int" value="0"/>
-      <Option name="variableNames" type="StringList">
-        <Option type="QString" value="interlis_topic"/>
+      <Option value="0" type="int" name="embeddedWidgets/count"/>
+      <Option type="StringList" name="variableNames">
+        <Option value="interlis_topic" type="QString"/>
       </Option>
-      <Option name="variableValues" type="StringList">
-        <Option type="QString" value="LG_GeolAssets_V2.GeolAssets"/>
+      <Option type="StringList" name="variableValues">
+        <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
       </Option>
     </Option>
   </customproperties>
   <fieldConfiguration>
-    <field name="T_Id" configurationFlags="None">
+    <field configurationFlags="None" name="T_Id">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="T_basket" configurationFlags="None">
+    <field configurationFlags="None" name="T_basket">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_9a69fa2e_5fe3_4394_b675_9254fd08b57b"/>
-            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_contact_initiator_T_basket_T_ILI2DB_BASKET_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="T_ILI2DB_BASKET_9a69fa2e_5fe3_4394_b675_9254fd08b57b" type="QString" name="ReferencedLayerId"/>
+            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_contact_initiator_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="initiatedassetitem_assetitem" configurationFlags="None">
+    <field configurationFlags="None" name="initiatedassetitem_assetitem">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=assetitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="AssetItem_881b3b01_524b_4b04_8156_c2e457353572"/>
-            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_contact_initiator_initiatedassetitem_assetitem_assetitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=assetitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="AssetItem_881b3b01_524b_4b04_8156_c2e457353572" type="QString" name="ReferencedLayerId"/>
+            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_contact_initiator_initiatedassetitem_assetitem_assetitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" configurationFlags="None">
+    <field configurationFlags="None" name="initiatedassetitem_lg_geolssts_v2geolassets_assetitem">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
-            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_contact_initiator_initiatedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d" type="QString" name="ReferencedLayerId"/>
+            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_contact_initiator_initiatedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="initiator_contact" configurationFlags="None">
+    <field configurationFlags="None" name="initiator_contact">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=contact"/>
-            <Option name="ReferencedLayerId" type="QString" value="Contact_c10e01b5_6f3e_4b43_bfd7_998c10d7d4ba"/>
-            <Option name="ReferencedLayerName" type="QString" value="Contact"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_contact_initiator_initiator_contact_contact_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=contact" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="Contact_c10e01b5_6f3e_4b43_bfd7_998c10d7d4ba" type="QString" name="ReferencedLayerId"/>
+            <Option value="Contact" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_contact_initiator_initiator_contact_contact_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="initiator_lg_geolssts_v2geolassets_contact" configurationFlags="None">
+    <field configurationFlags="None" name="initiator_lg_geolssts_v2geolassets_contact">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_contact"/>
-            <Option name="ReferencedLayerId" type="QString" value="Contact_c7ed9e21_34ff_45ef_9ca6_0556cc627cd5"/>
-            <Option name="ReferencedLayerName" type="QString" value="Contact"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_contact_initiator_initiator_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_contact" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="Contact_c7ed9e21_34ff_45ef_9ca6_0556cc627cd5" type="QString" name="ReferencedLayerId"/>
+            <Option value="Contact" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_contact_initiator_initiator_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="T_Id"/>
-    <alias name="" index="1" field="T_basket"/>
-    <alias name="InitiatedAssetItem" index="2" field="initiatedassetitem_assetitem"/>
-    <alias name="Asset Item" index="3" field="initiatedassetitem_lg_geolssts_v2geolassets_assetitem"/>
-    <alias name="Initiator" index="4" field="initiator_contact"/>
-    <alias name="Initiator  LG" index="5" field="initiator_lg_geolssts_v2geolassets_contact"/>
+    <alias field="T_Id" index="0" name=""/>
+    <alias field="T_basket" index="1" name=""/>
+    <alias field="initiatedassetitem_assetitem" index="2" name="InitiatedAssetItem"/>
+    <alias field="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" index="3" name="Asset Item"/>
+    <alias field="initiator_contact" index="4" name="Initiator"/>
+    <alias field="initiator_lg_geolssts_v2geolassets_contact" index="5" name="Initiator  LG"/>
   </aliases>
   <defaults>
-    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
-    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
-    <default applyOnUpdate="0" field="initiatedassetitem_assetitem" expression=""/>
-    <default applyOnUpdate="0" field="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" expression=""/>
-    <default applyOnUpdate="0" field="initiator_contact" expression=""/>
-    <default applyOnUpdate="0" field="initiator_lg_geolssts_v2geolassets_contact" expression=""/>
+    <default expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" field="T_Id" applyOnUpdate="0"/>
+    <default expression="@default_basket_lg_geolassets_v2_geolassets" field="T_basket" applyOnUpdate="0"/>
+    <default expression="" field="initiatedassetitem_assetitem" applyOnUpdate="0"/>
+    <default expression="" field="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" applyOnUpdate="0"/>
+    <default expression="" field="initiator_contact" applyOnUpdate="0"/>
+    <default expression="" field="initiator_lg_geolssts_v2geolassets_contact" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="initiatedassetitem_assetitem" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="initiator_contact" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="initiator_lg_geolssts_v2geolassets_contact" notnull_strength="0" exp_strength="0"/>
+    <constraint field="T_Id" exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3"/>
+    <constraint field="T_basket" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint field="initiatedassetitem_assetitem" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="initiator_contact" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="initiator_lg_geolssts_v2geolassets_contact" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="T_Id" desc=""/>
@@ -191,23 +191,23 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField name="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" index="3" showLabel="1"/>
+    <attributeEditorField index="3" showLabel="1" name="initiatedassetitem_lg_geolssts_v2geolassets_assetitem"/>
   </attributeEditorForm>
   <editable>
-    <field name="T_Id" editable="1"/>
-    <field name="T_basket" editable="1"/>
-    <field name="initiatedassetitem_assetitem" editable="1"/>
-    <field name="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" editable="0"/>
-    <field name="initiator_contact" editable="1"/>
-    <field name="initiator_lg_geolssts_v2geolassets_contact" editable="1"/>
+    <field editable="1" name="T_Id"/>
+    <field editable="1" name="T_basket"/>
+    <field editable="1" name="initiatedassetitem_assetitem"/>
+    <field editable="0" name="initiatedassetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <field editable="1" name="initiator_contact"/>
+    <field editable="1" name="initiator_lg_geolssts_v2geolassets_contact"/>
   </editable>
   <labelOnTop>
-    <field name="T_Id" labelOnTop="0"/>
-    <field name="T_basket" labelOnTop="0"/>
-    <field name="initiatedassetitem_assetitem" labelOnTop="0"/>
-    <field name="initiatedassetitem_lg_geolssts_v2geolassets_assetitem" labelOnTop="0"/>
-    <field name="initiator_contact" labelOnTop="0"/>
-    <field name="initiator_lg_geolssts_v2geolassets_contact" labelOnTop="0"/>
+    <field labelOnTop="0" name="T_Id"/>
+    <field labelOnTop="0" name="T_basket"/>
+    <field labelOnTop="0" name="initiatedassetitem_assetitem"/>
+    <field labelOnTop="0" name="initiatedassetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <field labelOnTop="0" name="initiator_contact"/>
+    <field labelOnTop="0" name="initiator_lg_geolssts_v2geolassets_contact"/>
   </labelOnTop>
   <reuseLastValue>
     <field reuseLastValue="0" name="T_Id"/>
@@ -219,6 +219,6 @@ def my_form_open(dialog, layer, feature):
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>
-  <previewExpression>attribute(get_feature('AssetItem', 'T_Id',  "initiatedassetitem_lg_geolssts_v2geolassets_assetitem" ),'titleoriginal')</previewExpression>
+  <previewExpression>coalesce( attribute(get_feature('AssetItem', 'T_Id', "initiatedassetitem_lg_geolssts_v2geolassets_assetitem"),'titlepublic'),'Kein Öffentlicher Titel vorhanden' )</previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/layerstyle/assetitem_contact_supplier.qml
+++ b/lg_geolassets_v2/layerstyle/assetitem_contact_supplier.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="LayerConfiguration|Fields|Forms|CustomProperties" readOnly="0" version="3.24.3-Tisler">
+<qgis readOnly="0" version="3.22.11-Białowieża" styleCategories="LayerConfiguration|Fields|Forms|CustomProperties">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -8,155 +8,155 @@
   </flags>
   <customproperties>
     <Option type="Map">
-      <Option name="QFieldSync/action" type="QString" value="copy"/>
-      <Option name="QFieldSync/cloud_action" type="QString" value="offline"/>
-      <Option name="QFieldSync/photo_naming" type="QString" value="{}"/>
-      <Option name="dualview/previewExpressions" type="List">
-        <Option type="QString" value="attribute(get_feature('AssetItem', 'T_Id',  &quot;suppliedassetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'titleoriginal')"/>
-        <Option type="QString" value="&quot;T_Id&quot;"/>
-        <Option type="QString" value="attribute(get_feature('AssetItem', 'T_Id', &quot;authoredassetitem_lg_geolssts_v2geolassets_assetitem&quot;),'titleoriginal')"/>
+      <Option value="copy" type="QString" name="QFieldSync/action"/>
+      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
+      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
+      <Option type="List" name="dualview/previewExpressions">
+        <Option value="attribute(get_feature('AssetItem', 'T_Id',  &quot;suppliedassetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'titleoriginal')" type="QString"/>
+        <Option value="&quot;T_Id&quot;" type="QString"/>
+        <Option value="attribute(get_feature('AssetItem', 'T_Id', &quot;authoredassetitem_lg_geolssts_v2geolassets_assetitem&quot;),'titleoriginal')" type="QString"/>
       </Option>
-      <Option name="embeddedWidgets/count" type="int" value="0"/>
-      <Option name="variableNames" type="StringList">
-        <Option type="QString" value="interlis_topic"/>
+      <Option value="0" type="int" name="embeddedWidgets/count"/>
+      <Option type="StringList" name="variableNames">
+        <Option value="interlis_topic" type="QString"/>
       </Option>
-      <Option name="variableValues" type="StringList">
-        <Option type="QString" value="LG_GeolAssets_V2.GeolAssets"/>
+      <Option type="StringList" name="variableValues">
+        <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
       </Option>
     </Option>
   </customproperties>
   <fieldConfiguration>
-    <field name="T_Id" configurationFlags="None">
+    <field configurationFlags="None" name="T_Id">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="T_basket" configurationFlags="None">
+    <field configurationFlags="None" name="T_basket">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_9a69fa2e_5fe3_4394_b675_9254fd08b57b"/>
-            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_contact_supplier_T_basket_T_ILI2DB_BASKET_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="T_ILI2DB_BASKET_9a69fa2e_5fe3_4394_b675_9254fd08b57b" type="QString" name="ReferencedLayerId"/>
+            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_contact_supplier_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="suppliedassetitem_assetitem" configurationFlags="None">
+    <field configurationFlags="None" name="suppliedassetitem_assetitem">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=assetitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="AssetItem_881b3b01_524b_4b04_8156_c2e457353572"/>
-            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_contact_supplier_suppliedassetitem_assetitem_assetitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=assetitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="AssetItem_881b3b01_524b_4b04_8156_c2e457353572" type="QString" name="ReferencedLayerId"/>
+            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_contact_supplier_suppliedassetitem_assetitem_assetitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" configurationFlags="None">
+    <field configurationFlags="None" name="suppliedassetitem_lg_geolssts_v2geolassets_assetitem">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
-            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_contact_supplier_suppliedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d" type="QString" name="ReferencedLayerId"/>
+            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_contact_supplier_suppliedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="supplier_contact" configurationFlags="None">
+    <field configurationFlags="None" name="supplier_contact">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=contact"/>
-            <Option name="ReferencedLayerId" type="QString" value="Contact_c10e01b5_6f3e_4b43_bfd7_998c10d7d4ba"/>
-            <Option name="ReferencedLayerName" type="QString" value="Contact"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_contact_supplier_supplier_contact_contact_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=contact" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="Contact_c10e01b5_6f3e_4b43_bfd7_998c10d7d4ba" type="QString" name="ReferencedLayerId"/>
+            <Option value="Contact" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_contact_supplier_supplier_contact_contact_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="supplier_lg_geolssts_v2geolassets_contact" configurationFlags="None">
+    <field configurationFlags="None" name="supplier_lg_geolssts_v2geolassets_contact">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_contact"/>
-            <Option name="ReferencedLayerId" type="QString" value="Contact_c7ed9e21_34ff_45ef_9ca6_0556cc627cd5"/>
-            <Option name="ReferencedLayerName" type="QString" value="Contact"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_contact_supplier_supplier_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_contact" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="Contact_c7ed9e21_34ff_45ef_9ca6_0556cc627cd5" type="QString" name="ReferencedLayerId"/>
+            <Option value="Contact" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_contact_supplier_supplier_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="T_Id"/>
-    <alias name="" index="1" field="T_basket"/>
-    <alias name="SuppliedAssetItem" index="2" field="suppliedassetitem_assetitem"/>
-    <alias name="Asset Item" index="3" field="suppliedassetitem_lg_geolssts_v2geolassets_assetitem"/>
-    <alias name="Supplier" index="4" field="supplier_contact"/>
-    <alias name="Supplier  LG" index="5" field="supplier_lg_geolssts_v2geolassets_contact"/>
+    <alias field="T_Id" index="0" name=""/>
+    <alias field="T_basket" index="1" name=""/>
+    <alias field="suppliedassetitem_assetitem" index="2" name="SuppliedAssetItem"/>
+    <alias field="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" index="3" name="Asset Item"/>
+    <alias field="supplier_contact" index="4" name="Supplier"/>
+    <alias field="supplier_lg_geolssts_v2geolassets_contact" index="5" name="Supplier  LG"/>
   </aliases>
   <defaults>
-    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
-    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
-    <default applyOnUpdate="0" field="suppliedassetitem_assetitem" expression=""/>
-    <default applyOnUpdate="0" field="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" expression=""/>
-    <default applyOnUpdate="0" field="supplier_contact" expression=""/>
-    <default applyOnUpdate="0" field="supplier_lg_geolssts_v2geolassets_contact" expression=""/>
+    <default expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" field="T_Id" applyOnUpdate="0"/>
+    <default expression="@default_basket_lg_geolassets_v2_geolassets" field="T_basket" applyOnUpdate="0"/>
+    <default expression="" field="suppliedassetitem_assetitem" applyOnUpdate="0"/>
+    <default expression="" field="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" applyOnUpdate="0"/>
+    <default expression="" field="supplier_contact" applyOnUpdate="0"/>
+    <default expression="" field="supplier_lg_geolssts_v2geolassets_contact" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="suppliedassetitem_assetitem" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="supplier_contact" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="supplier_lg_geolssts_v2geolassets_contact" notnull_strength="0" exp_strength="0"/>
+    <constraint field="T_Id" exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3"/>
+    <constraint field="T_basket" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint field="suppliedassetitem_assetitem" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="supplier_contact" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="supplier_lg_geolssts_v2geolassets_contact" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="T_Id" desc=""/>
@@ -191,23 +191,23 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField name="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" index="3" showLabel="1"/>
+    <attributeEditorField index="3" showLabel="1" name="suppliedassetitem_lg_geolssts_v2geolassets_assetitem"/>
   </attributeEditorForm>
   <editable>
-    <field name="T_Id" editable="1"/>
-    <field name="T_basket" editable="1"/>
-    <field name="suppliedassetitem_assetitem" editable="1"/>
-    <field name="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" editable="0"/>
-    <field name="supplier_contact" editable="1"/>
-    <field name="supplier_lg_geolssts_v2geolassets_contact" editable="1"/>
+    <field editable="1" name="T_Id"/>
+    <field editable="1" name="T_basket"/>
+    <field editable="1" name="suppliedassetitem_assetitem"/>
+    <field editable="0" name="suppliedassetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <field editable="1" name="supplier_contact"/>
+    <field editable="1" name="supplier_lg_geolssts_v2geolassets_contact"/>
   </editable>
   <labelOnTop>
-    <field name="T_Id" labelOnTop="0"/>
-    <field name="T_basket" labelOnTop="0"/>
-    <field name="suppliedassetitem_assetitem" labelOnTop="0"/>
-    <field name="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" labelOnTop="0"/>
-    <field name="supplier_contact" labelOnTop="0"/>
-    <field name="supplier_lg_geolssts_v2geolassets_contact" labelOnTop="0"/>
+    <field labelOnTop="0" name="T_Id"/>
+    <field labelOnTop="0" name="T_basket"/>
+    <field labelOnTop="0" name="suppliedassetitem_assetitem"/>
+    <field labelOnTop="0" name="suppliedassetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <field labelOnTop="0" name="supplier_contact"/>
+    <field labelOnTop="0" name="supplier_lg_geolssts_v2geolassets_contact"/>
   </labelOnTop>
   <reuseLastValue>
     <field reuseLastValue="0" name="T_Id"/>
@@ -219,6 +219,6 @@ def my_form_open(dialog, layer, feature):
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>
-  <previewExpression>attribute(get_feature('AssetItem', 'T_Id',  "suppliedassetitem_lg_geolssts_v2geolassets_assetitem" ),'titleoriginal')</previewExpression>
+  <previewExpression>coalesce( attribute(get_feature('AssetItem', 'T_Id', "suppliedassetitem_lg_geolssts_v2geolassets_assetitem"),'titlepublic'),'Kein Öffentlicher Titel vorhanden' )</previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/layerstyle/assetitem_contact_supplier.qml
+++ b/lg_geolassets_v2/layerstyle/assetitem_contact_supplier.qml
@@ -1,62 +1,224 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="Fields|CustomProperties" version="3.25.0-Master">
+<qgis styleCategories="LayerConfiguration|Fields|Forms|CustomProperties" readOnly="0" version="3.24.3-Tisler">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
   <customproperties>
     <Option type="Map">
-      <Option value="copy" type="QString" name="QFieldSync/action"/>
-      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
-      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
-      <Option type="List" name="dualview/previewExpressions">
-        <Option value="&quot;T_Id&quot;" type="QString"/>
+      <Option name="QFieldSync/action" type="QString" value="copy"/>
+      <Option name="QFieldSync/cloud_action" type="QString" value="offline"/>
+      <Option name="QFieldSync/photo_naming" type="QString" value="{}"/>
+      <Option name="dualview/previewExpressions" type="List">
+        <Option type="QString" value="attribute(get_feature('AssetItem', 'T_Id',  &quot;suppliedassetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'titleoriginal')"/>
+        <Option type="QString" value="&quot;T_Id&quot;"/>
+        <Option type="QString" value="attribute(get_feature('AssetItem', 'T_Id', &quot;authoredassetitem_lg_geolssts_v2geolassets_assetitem&quot;),'titleoriginal')"/>
       </Option>
-      <Option value="0" type="int" name="embeddedWidgets/count"/>
-      <Option type="StringList" name="variableNames">
-        <Option value="interlis_topic" type="QString"/>
+      <Option name="embeddedWidgets/count" type="int" value="0"/>
+      <Option name="variableNames" type="StringList">
+        <Option type="QString" value="interlis_topic"/>
       </Option>
-      <Option type="StringList" name="variableValues">
-        <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
+      <Option name="variableValues" type="StringList">
+        <Option type="QString" value="LG_GeolAssets_V2.GeolAssets"/>
       </Option>
     </Option>
   </customproperties>
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id"/>
-    <field configurationFlags="None" name="T_basket"/>
-    <field configurationFlags="None" name="suppliedassetitem_assetitem"/>
-    <field configurationFlags="None" name="suppliedassetitem_lg_geolssts_v2geolassets_assetitem"/>
-    <field configurationFlags="None" name="supplier_contact"/>
-    <field configurationFlags="None" name="supplier_lg_geolssts_v2geolassets_contact"/>
+    <field name="T_Id" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="T_basket" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_9a69fa2e_5fe3_4394_b675_9254fd08b57b"/>
+            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_contact_supplier_T_basket_T_ILI2DB_BASKET_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="suppliedassetitem_assetitem" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=assetitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetItem_881b3b01_524b_4b04_8156_c2e457353572"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_contact_supplier_suppliedassetitem_assetitem_assetitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_contact_supplier_suppliedassetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="supplier_contact" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=contact"/>
+            <Option name="ReferencedLayerId" type="QString" value="Contact_c10e01b5_6f3e_4b43_bfd7_998c10d7d4ba"/>
+            <Option name="ReferencedLayerName" type="QString" value="Contact"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_contact_supplier_supplier_contact_contact_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="supplier_lg_geolssts_v2geolassets_contact" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_contact"/>
+            <Option name="ReferencedLayerId" type="QString" value="Contact_c7ed9e21_34ff_45ef_9ca6_0556cc627cd5"/>
+            <Option name="ReferencedLayerName" type="QString" value="Contact"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_contact_supplier_supplier_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="T_Id" index="0" name=""/>
-    <alias field="T_basket" index="1" name=""/>
-    <alias field="suppliedassetitem_assetitem" index="2" name="SuppliedAssetItem"/>
-    <alias field="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" index="3" name="SuppliedAssetItem LG"/>
-    <alias field="supplier_contact" index="4" name="Supplier"/>
-    <alias field="supplier_lg_geolssts_v2geolassets_contact" index="5" name="Supplier  LG"/>
+    <alias name="" index="0" field="T_Id"/>
+    <alias name="" index="1" field="T_basket"/>
+    <alias name="SuppliedAssetItem" index="2" field="suppliedassetitem_assetitem"/>
+    <alias name="Asset Item" index="3" field="suppliedassetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <alias name="Supplier" index="4" field="supplier_contact"/>
+    <alias name="Supplier  LG" index="5" field="supplier_lg_geolssts_v2geolassets_contact"/>
   </aliases>
   <defaults>
-    <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
-    <default field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets" applyOnUpdate="0"/>
-    <default field="suppliedassetitem_assetitem" expression="" applyOnUpdate="0"/>
-    <default field="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" expression="" applyOnUpdate="0"/>
-    <default field="supplier_contact" expression="" applyOnUpdate="0"/>
-    <default field="supplier_lg_geolssts_v2geolassets_contact" expression="" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
+    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
+    <default applyOnUpdate="0" field="suppliedassetitem_assetitem" expression=""/>
+    <default applyOnUpdate="0" field="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" expression=""/>
+    <default applyOnUpdate="0" field="supplier_contact" expression=""/>
+    <default applyOnUpdate="0" field="supplier_lg_geolssts_v2geolassets_contact" expression=""/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" notnull_strength="1" field="T_Id" exp_strength="0" constraints="3"/>
-    <constraint unique_strength="0" notnull_strength="1" field="T_basket" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="suppliedassetitem_assetitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="supplier_contact" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="supplier_lg_geolssts_v2geolassets_contact" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="suppliedassetitem_assetitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="supplier_contact" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="supplier_lg_geolssts_v2geolassets_contact" notnull_strength="0" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="T_Id" desc="" exp=""/>
-    <constraint field="T_basket" desc="" exp=""/>
-    <constraint field="suppliedassetitem_assetitem" desc="" exp=""/>
-    <constraint field="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" desc="" exp=""/>
-    <constraint field="supplier_contact" desc="" exp=""/>
-    <constraint field="supplier_lg_geolssts_v2geolassets_contact" desc="" exp=""/>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="suppliedassetitem_assetitem" desc=""/>
+    <constraint exp="" field="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" desc=""/>
+    <constraint exp="" field="supplier_contact" desc=""/>
+    <constraint exp="" field="supplier_lg_geolssts_v2geolassets_contact" desc=""/>
   </constraintExpressions>
   <expressionfields/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorField name="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" index="3" showLabel="1"/>
+  </attributeEditorForm>
+  <editable>
+    <field name="T_Id" editable="1"/>
+    <field name="T_basket" editable="1"/>
+    <field name="suppliedassetitem_assetitem" editable="1"/>
+    <field name="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" editable="0"/>
+    <field name="supplier_contact" editable="1"/>
+    <field name="supplier_lg_geolssts_v2geolassets_contact" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="T_Id" labelOnTop="0"/>
+    <field name="T_basket" labelOnTop="0"/>
+    <field name="suppliedassetitem_assetitem" labelOnTop="0"/>
+    <field name="suppliedassetitem_lg_geolssts_v2geolassets_assetitem" labelOnTop="0"/>
+    <field name="supplier_contact" labelOnTop="0"/>
+    <field name="supplier_lg_geolssts_v2geolassets_contact" labelOnTop="0"/>
+  </labelOnTop>
+  <reuseLastValue>
+    <field reuseLastValue="0" name="T_Id"/>
+    <field reuseLastValue="0" name="T_basket"/>
+    <field reuseLastValue="0" name="suppliedassetitem_assetitem"/>
+    <field reuseLastValue="0" name="suppliedassetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <field reuseLastValue="0" name="supplier_contact"/>
+    <field reuseLastValue="0" name="supplier_lg_geolssts_v2geolassets_contact"/>
+  </reuseLastValue>
+  <dataDefinedFieldProperties/>
+  <widgets/>
+  <previewExpression>attribute(get_feature('AssetItem', 'T_Id',  "suppliedassetitem_lg_geolssts_v2geolassets_assetitem" ),'titleoriginal')</previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/layerstyle/assetitem_publication.qml
+++ b/lg_geolassets_v2/layerstyle/assetitem_publication.qml
@@ -1,49 +1,165 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="Fields|CustomProperties" version="3.25.0-Master">
+<qgis styleCategories="LayerConfiguration|Fields|Forms|CustomProperties" readOnly="0" version="3.24.3-Tisler">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
   <customproperties>
     <Option type="Map">
-      <Option value="copy" type="QString" name="QFieldSync/action"/>
-      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
-      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
-      <Option value="0" type="int" name="embeddedWidgets/count"/>
-      <Option type="StringList" name="variableNames">
-        <Option value="interlis_topic" type="QString"/>
+      <Option name="QFieldSync/action" type="QString" value="copy"/>
+      <Option name="QFieldSync/cloud_action" type="QString" value="offline"/>
+      <Option name="QFieldSync/photo_naming" type="QString" value="{}"/>
+      <Option name="embeddedWidgets/count" type="int" value="0"/>
+      <Option name="variableNames" type="StringList">
+        <Option type="QString" value="interlis_topic"/>
       </Option>
-      <Option type="StringList" name="variableValues">
-        <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
+      <Option name="variableValues" type="StringList">
+        <Option type="QString" value="LG_GeolAssets_V2.GeolAssets"/>
       </Option>
     </Option>
   </customproperties>
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id"/>
-    <field configurationFlags="None" name="T_basket"/>
-    <field configurationFlags="None" name="assetitem"/>
-    <field configurationFlags="None" name="publication"/>
+    <field name="T_Id" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="T_basket" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_9a69fa2e_5fe3_4394_b675_9254fd08b57b"/>
+            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_publication_T_basket_T_ILI2DB_BASKET_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="assetitem" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_publication_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="publication" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=publication"/>
+            <Option name="ReferencedLayerId" type="QString" value="Publication_f5b43e58_e7c2_4d5e_8145_0ef94c8e30dc"/>
+            <Option name="ReferencedLayerName" type="QString" value="Publication"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_publication_publication_publication_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="T_Id" index="0" name=""/>
-    <alias field="T_basket" index="1" name=""/>
-    <alias field="assetitem" index="2" name="AssetItem"/>
-    <alias field="publication" index="3" name="Publication"/>
+    <alias name="" index="0" field="T_Id"/>
+    <alias name="" index="1" field="T_basket"/>
+    <alias name="Asset Item" index="2" field="assetitem"/>
+    <alias name="Publication" index="3" field="publication"/>
   </aliases>
   <defaults>
-    <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
-    <default field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets" applyOnUpdate="0"/>
-    <default field="assetitem" expression="" applyOnUpdate="0"/>
-    <default field="publication" expression="" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
+    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
+    <default applyOnUpdate="0" field="assetitem" expression=""/>
+    <default applyOnUpdate="0" field="publication" expression=""/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" notnull_strength="1" field="T_Id" exp_strength="0" constraints="3"/>
-    <constraint unique_strength="0" notnull_strength="1" field="T_basket" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="1" field="assetitem" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="1" field="publication" exp_strength="0" constraints="1"/>
+    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="assetitem" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="publication" notnull_strength="1" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="T_Id" desc="" exp=""/>
-    <constraint field="T_basket" desc="" exp=""/>
-    <constraint field="assetitem" desc="" exp=""/>
-    <constraint field="publication" desc="" exp=""/>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="assetitem" desc=""/>
+    <constraint exp="" field="publication" desc=""/>
   </constraintExpressions>
   <expressionfields/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorField name="assetitem" index="2" showLabel="1"/>
+  </attributeEditorForm>
+  <editable>
+    <field name="T_Id" editable="1"/>
+    <field name="T_basket" editable="1"/>
+    <field name="assetitem" editable="0"/>
+    <field name="publication" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="T_Id" labelOnTop="0"/>
+    <field name="T_basket" labelOnTop="0"/>
+    <field name="assetitem" labelOnTop="0"/>
+    <field name="publication" labelOnTop="0"/>
+  </labelOnTop>
+  <reuseLastValue>
+    <field reuseLastValue="0" name="T_Id"/>
+    <field reuseLastValue="0" name="T_basket"/>
+    <field reuseLastValue="0" name="assetitem"/>
+    <field reuseLastValue="0" name="publication"/>
+  </reuseLastValue>
+  <dataDefinedFieldProperties/>
+  <widgets/>
+  <previewExpression>attribute(get_feature('AssetItem', 'T_Id',  "assetitem" ),'titleoriginal') </previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/layerstyle/assetitem_publication.qml
+++ b/lg_geolassets_v2/layerstyle/assetitem_publication.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="LayerConfiguration|Fields|Forms|CustomProperties" readOnly="0" version="3.24.3-Tisler">
+<qgis readOnly="0" version="3.22.11-Białowieża" styleCategories="LayerConfiguration|Fields|Forms|CustomProperties">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -8,104 +8,104 @@
   </flags>
   <customproperties>
     <Option type="Map">
-      <Option name="QFieldSync/action" type="QString" value="copy"/>
-      <Option name="QFieldSync/cloud_action" type="QString" value="offline"/>
-      <Option name="QFieldSync/photo_naming" type="QString" value="{}"/>
-      <Option name="embeddedWidgets/count" type="int" value="0"/>
-      <Option name="variableNames" type="StringList">
-        <Option type="QString" value="interlis_topic"/>
+      <Option value="copy" type="QString" name="QFieldSync/action"/>
+      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
+      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
+      <Option value="0" type="int" name="embeddedWidgets/count"/>
+      <Option type="StringList" name="variableNames">
+        <Option value="interlis_topic" type="QString"/>
       </Option>
-      <Option name="variableValues" type="StringList">
-        <Option type="QString" value="LG_GeolAssets_V2.GeolAssets"/>
+      <Option type="StringList" name="variableValues">
+        <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
       </Option>
     </Option>
   </customproperties>
   <fieldConfiguration>
-    <field name="T_Id" configurationFlags="None">
+    <field configurationFlags="None" name="T_Id">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="T_basket" configurationFlags="None">
+    <field configurationFlags="None" name="T_basket">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_9a69fa2e_5fe3_4394_b675_9254fd08b57b"/>
-            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_publication_T_basket_T_ILI2DB_BASKET_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="T_ILI2DB_BASKET_9a69fa2e_5fe3_4394_b675_9254fd08b57b" type="QString" name="ReferencedLayerId"/>
+            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_publication_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="assetitem" configurationFlags="None">
+    <field configurationFlags="None" name="assetitem">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
-            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_publication_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d" type="QString" name="ReferencedLayerId"/>
+            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_publication_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="publication" configurationFlags="None">
+    <field configurationFlags="None" name="publication">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=publication"/>
-            <Option name="ReferencedLayerId" type="QString" value="Publication_f5b43e58_e7c2_4d5e_8145_0ef94c8e30dc"/>
-            <Option name="ReferencedLayerName" type="QString" value="Publication"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_publication_publication_publication_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=publication" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="Publication_f5b43e58_e7c2_4d5e_8145_0ef94c8e30dc" type="QString" name="ReferencedLayerId"/>
+            <Option value="Publication" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_publication_publication_publication_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="T_Id"/>
-    <alias name="" index="1" field="T_basket"/>
-    <alias name="Asset Item" index="2" field="assetitem"/>
-    <alias name="Publication" index="3" field="publication"/>
+    <alias field="T_Id" index="0" name=""/>
+    <alias field="T_basket" index="1" name=""/>
+    <alias field="assetitem" index="2" name="Asset Item"/>
+    <alias field="publication" index="3" name="Publication"/>
   </aliases>
   <defaults>
-    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
-    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
-    <default applyOnUpdate="0" field="assetitem" expression=""/>
-    <default applyOnUpdate="0" field="publication" expression=""/>
+    <default expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" field="T_Id" applyOnUpdate="0"/>
+    <default expression="@default_basket_lg_geolassets_v2_geolassets" field="T_basket" applyOnUpdate="0"/>
+    <default expression="" field="assetitem" applyOnUpdate="0"/>
+    <default expression="" field="publication" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" field="assetitem" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" field="publication" notnull_strength="1" exp_strength="0"/>
+    <constraint field="T_Id" exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3"/>
+    <constraint field="T_basket" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint field="assetitem" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint field="publication" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="T_Id" desc=""/>
@@ -138,19 +138,19 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField name="assetitem" index="2" showLabel="1"/>
+    <attributeEditorField index="2" showLabel="1" name="assetitem"/>
   </attributeEditorForm>
   <editable>
-    <field name="T_Id" editable="1"/>
-    <field name="T_basket" editable="1"/>
-    <field name="assetitem" editable="0"/>
-    <field name="publication" editable="1"/>
+    <field editable="1" name="T_Id"/>
+    <field editable="1" name="T_basket"/>
+    <field editable="0" name="assetitem"/>
+    <field editable="1" name="publication"/>
   </editable>
   <labelOnTop>
-    <field name="T_Id" labelOnTop="0"/>
-    <field name="T_basket" labelOnTop="0"/>
-    <field name="assetitem" labelOnTop="0"/>
-    <field name="publication" labelOnTop="0"/>
+    <field labelOnTop="0" name="T_Id"/>
+    <field labelOnTop="0" name="T_basket"/>
+    <field labelOnTop="0" name="assetitem"/>
+    <field labelOnTop="0" name="publication"/>
   </labelOnTop>
   <reuseLastValue>
     <field reuseLastValue="0" name="T_Id"/>
@@ -160,6 +160,7 @@ def my_form_open(dialog, layer, feature):
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>
-  <previewExpression>attribute(get_feature('AssetItem', 'T_Id',  "assetitem" ),'titleoriginal') </previewExpression>
+  <previewExpression>coalesce( attribute(get_feature('AssetItem', 'T_Id', "assetitem"),'titlepublic'),'Kein Öffentlicher Titel vorhanden' )
+</previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/layerstyle/assetitem_usedby.qml
+++ b/lg_geolassets_v2/layerstyle/assetitem_usedby.qml
@@ -1,49 +1,165 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="Fields|CustomProperties" version="3.25.0-Master">
+<qgis styleCategories="LayerConfiguration|Fields|Forms|CustomProperties" readOnly="0" version="3.24.3-Tisler">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
   <customproperties>
     <Option type="Map">
-      <Option value="copy" type="QString" name="QFieldSync/action"/>
-      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
-      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
-      <Option value="0" type="int" name="embeddedWidgets/count"/>
-      <Option type="StringList" name="variableNames">
-        <Option value="interlis_topic" type="QString"/>
+      <Option name="QFieldSync/action" type="QString" value="copy"/>
+      <Option name="QFieldSync/cloud_action" type="QString" value="offline"/>
+      <Option name="QFieldSync/photo_naming" type="QString" value="{}"/>
+      <Option name="embeddedWidgets/count" type="int" value="0"/>
+      <Option name="variableNames" type="StringList">
+        <Option type="QString" value="interlis_topic"/>
       </Option>
-      <Option type="StringList" name="variableValues">
-        <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
+      <Option name="variableValues" type="StringList">
+        <Option type="QString" value="LG_GeolAssets_V2.GeolAssets"/>
       </Option>
     </Option>
   </customproperties>
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id"/>
-    <field configurationFlags="None" name="T_basket"/>
-    <field configurationFlags="None" name="assetitem"/>
-    <field configurationFlags="None" name="usedby"/>
+    <field name="T_Id" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="T_basket" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_9a69fa2e_5fe3_4394_b675_9254fd08b57b"/>
+            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_usedby_T_basket_T_ILI2DB_BASKET_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="assetitem" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_usedby_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="usedby" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=internalproject"/>
+            <Option name="ReferencedLayerId" type="QString" value="InternalProject_c71db676_a47e_4a66_8a94_c52bd7a7b706"/>
+            <Option name="ReferencedLayerName" type="QString" value="InternalProject"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="assetitem_usedby_usedby_internalproject_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="T_Id" index="0" name=""/>
-    <alias field="T_basket" index="1" name=""/>
-    <alias field="assetitem" index="2" name="AssetItem"/>
-    <alias field="usedby" index="3" name="UsedBy"/>
+    <alias name="" index="0" field="T_Id"/>
+    <alias name="" index="1" field="T_basket"/>
+    <alias name="AssetItem" index="2" field="assetitem"/>
+    <alias name="UsedBy" index="3" field="usedby"/>
   </aliases>
   <defaults>
-    <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
-    <default field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets" applyOnUpdate="0"/>
-    <default field="assetitem" expression="" applyOnUpdate="0"/>
-    <default field="usedby" expression="" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
+    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
+    <default applyOnUpdate="0" field="assetitem" expression=""/>
+    <default applyOnUpdate="0" field="usedby" expression=""/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" notnull_strength="1" field="T_Id" exp_strength="0" constraints="3"/>
-    <constraint unique_strength="0" notnull_strength="1" field="T_basket" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="1" field="assetitem" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="1" field="usedby" exp_strength="0" constraints="1"/>
+    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="assetitem" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="usedby" notnull_strength="1" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="T_Id" desc="" exp=""/>
-    <constraint field="T_basket" desc="" exp=""/>
-    <constraint field="assetitem" desc="" exp=""/>
-    <constraint field="usedby" desc="" exp=""/>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="assetitem" desc=""/>
+    <constraint exp="" field="usedby" desc=""/>
   </constraintExpressions>
   <expressionfields/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorField name="assetitem" index="2" showLabel="1"/>
+  </attributeEditorForm>
+  <editable>
+    <field name="T_Id" editable="1"/>
+    <field name="T_basket" editable="1"/>
+    <field name="assetitem" editable="0"/>
+    <field name="usedby" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="T_Id" labelOnTop="0"/>
+    <field name="T_basket" labelOnTop="0"/>
+    <field name="assetitem" labelOnTop="0"/>
+    <field name="usedby" labelOnTop="0"/>
+  </labelOnTop>
+  <reuseLastValue>
+    <field reuseLastValue="0" name="T_Id"/>
+    <field reuseLastValue="0" name="T_basket"/>
+    <field reuseLastValue="0" name="assetitem"/>
+    <field reuseLastValue="0" name="usedby"/>
+  </reuseLastValue>
+  <dataDefinedFieldProperties/>
+  <widgets/>
+  <previewExpression>attribute(get_feature('AssetItem', 'T_Id',  "assetitem" ),'titleoriginal') </previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/layerstyle/assetitem_usedby.qml
+++ b/lg_geolassets_v2/layerstyle/assetitem_usedby.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="LayerConfiguration|Fields|Forms|CustomProperties" readOnly="0" version="3.24.3-Tisler">
+<qgis readOnly="0" version="3.22.11-Białowieża" styleCategories="LayerConfiguration|Fields|Forms|CustomProperties">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -8,104 +8,104 @@
   </flags>
   <customproperties>
     <Option type="Map">
-      <Option name="QFieldSync/action" type="QString" value="copy"/>
-      <Option name="QFieldSync/cloud_action" type="QString" value="offline"/>
-      <Option name="QFieldSync/photo_naming" type="QString" value="{}"/>
-      <Option name="embeddedWidgets/count" type="int" value="0"/>
-      <Option name="variableNames" type="StringList">
-        <Option type="QString" value="interlis_topic"/>
+      <Option value="copy" type="QString" name="QFieldSync/action"/>
+      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
+      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
+      <Option value="0" type="int" name="embeddedWidgets/count"/>
+      <Option type="StringList" name="variableNames">
+        <Option value="interlis_topic" type="QString"/>
       </Option>
-      <Option name="variableValues" type="StringList">
-        <Option type="QString" value="LG_GeolAssets_V2.GeolAssets"/>
+      <Option type="StringList" name="variableValues">
+        <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
       </Option>
     </Option>
   </customproperties>
   <fieldConfiguration>
-    <field name="T_Id" configurationFlags="None">
+    <field configurationFlags="None" name="T_Id">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="T_basket" configurationFlags="None">
+    <field configurationFlags="None" name="T_basket">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_9a69fa2e_5fe3_4394_b675_9254fd08b57b"/>
-            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_usedby_T_basket_T_ILI2DB_BASKET_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="T_ILI2DB_BASKET_9a69fa2e_5fe3_4394_b675_9254fd08b57b" type="QString" name="ReferencedLayerId"/>
+            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_usedby_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="assetitem" configurationFlags="None">
+    <field configurationFlags="None" name="assetitem">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
-            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_usedby_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d" type="QString" name="ReferencedLayerId"/>
+            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_usedby_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="usedby" configurationFlags="None">
+    <field configurationFlags="None" name="usedby">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=internalproject"/>
-            <Option name="ReferencedLayerId" type="QString" value="InternalProject_c71db676_a47e_4a66_8a94_c52bd7a7b706"/>
-            <Option name="ReferencedLayerName" type="QString" value="InternalProject"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="assetitem_usedby_usedby_internalproject_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=internalproject" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="InternalProject_c71db676_a47e_4a66_8a94_c52bd7a7b706" type="QString" name="ReferencedLayerId"/>
+            <Option value="InternalProject" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="assetitem_usedby_usedby_internalproject_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="T_Id"/>
-    <alias name="" index="1" field="T_basket"/>
-    <alias name="AssetItem" index="2" field="assetitem"/>
-    <alias name="UsedBy" index="3" field="usedby"/>
+    <alias field="T_Id" index="0" name=""/>
+    <alias field="T_basket" index="1" name=""/>
+    <alias field="assetitem" index="2" name="AssetItem"/>
+    <alias field="usedby" index="3" name="UsedBy"/>
   </aliases>
   <defaults>
-    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
-    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
-    <default applyOnUpdate="0" field="assetitem" expression=""/>
-    <default applyOnUpdate="0" field="usedby" expression=""/>
+    <default expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" field="T_Id" applyOnUpdate="0"/>
+    <default expression="@default_basket_lg_geolassets_v2_geolassets" field="T_basket" applyOnUpdate="0"/>
+    <default expression="" field="assetitem" applyOnUpdate="0"/>
+    <default expression="" field="usedby" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" field="assetitem" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" field="usedby" notnull_strength="1" exp_strength="0"/>
+    <constraint field="T_Id" exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3"/>
+    <constraint field="T_basket" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint field="assetitem" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint field="usedby" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="T_Id" desc=""/>
@@ -138,19 +138,19 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField name="assetitem" index="2" showLabel="1"/>
+    <attributeEditorField index="2" showLabel="1" name="assetitem"/>
   </attributeEditorForm>
   <editable>
-    <field name="T_Id" editable="1"/>
-    <field name="T_basket" editable="1"/>
-    <field name="assetitem" editable="0"/>
-    <field name="usedby" editable="1"/>
+    <field editable="1" name="T_Id"/>
+    <field editable="1" name="T_basket"/>
+    <field editable="0" name="assetitem"/>
+    <field editable="1" name="usedby"/>
   </editable>
   <labelOnTop>
-    <field name="T_Id" labelOnTop="0"/>
-    <field name="T_basket" labelOnTop="0"/>
-    <field name="assetitem" labelOnTop="0"/>
-    <field name="usedby" labelOnTop="0"/>
+    <field labelOnTop="0" name="T_Id"/>
+    <field labelOnTop="0" name="T_basket"/>
+    <field labelOnTop="0" name="assetitem"/>
+    <field labelOnTop="0" name="usedby"/>
   </labelOnTop>
   <reuseLastValue>
     <field reuseLastValue="0" name="T_Id"/>
@@ -160,6 +160,7 @@ def my_form_open(dialog, layer, feature):
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>
-  <previewExpression>attribute(get_feature('AssetItem', 'T_Id',  "assetitem" ),'titleoriginal') </previewExpression>
+  <previewExpression>coalesce( attribute(get_feature('AssetItem', 'T_Id', "assetitem"),'titlepublic'),'Kein Öffentlicher Titel vorhanden' )
+</previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/layerstyle/contact.qml
+++ b/lg_geolassets_v2/layerstyle/contact.qml
@@ -4,7 +4,10 @@
     <field name="T_Id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
-          <Option/>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
         </config>
       </editWidget>
     </field>
@@ -34,7 +37,10 @@
     <field name="T_Ili_Tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
-          <Option/>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
         </config>
       </editWidget>
     </field>
@@ -113,37 +119,37 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" field="T_Id" index="0"/>
-    <alias name="" field="T_basket" index="1"/>
-    <alias name="" field="T_Ili_Tid" index="2"/>
-    <alias name="IDZAD" field="idzad" index="3"/>
-    <alias name="Art" field="akind" index="4"/>
-    <alias name="Name" field="aname" index="5"/>
-    <alias name="Telefon" field="telefon" index="6"/>
-    <alias name="Email (&quot;mailto:name@domain.ch&quot;)" field="email" index="7"/>
-    <alias name="Website (&quot;http://www.domain.ch&quot;)" field="website" index="8"/>
+    <alias name="" index="0" field="T_Id"/>
+    <alias name="" index="1" field="T_basket"/>
+    <alias name="" index="2" field="T_Ili_Tid"/>
+    <alias name="IDZAD" index="3" field="idzad"/>
+    <alias name="Art" index="4" field="akind"/>
+    <alias name="Name" index="5" field="aname"/>
+    <alias name="Telefon" index="6" field="telefon"/>
+    <alias name="Email (&quot;mailto:name@domain.ch&quot;)" index="7" field="email"/>
+    <alias name="Website (&quot;http://www.domain.ch&quot;)" index="8" field="website"/>
   </aliases>
   <defaults>
-    <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
-    <default field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets" applyOnUpdate="0"/>
-    <default field="T_Ili_Tid" expression="substr(uuid(), 2, 36)" applyOnUpdate="0"/>
-    <default field="idzad" expression="" applyOnUpdate="0"/>
-    <default field="akind" expression="" applyOnUpdate="0"/>
-    <default field="aname" expression="" applyOnUpdate="0"/>
-    <default field="telefon" expression="" applyOnUpdate="0"/>
-    <default field="email" expression="" applyOnUpdate="0"/>
-    <default field="website" expression="" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
+    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
+    <default applyOnUpdate="0" field="T_Ili_Tid" expression="substr(uuid(), 2, 36)"/>
+    <default applyOnUpdate="0" field="idzad" expression=""/>
+    <default applyOnUpdate="0" field="akind" expression=""/>
+    <default applyOnUpdate="0" field="aname" expression=""/>
+    <default applyOnUpdate="0" field="telefon" expression=""/>
+    <default applyOnUpdate="0" field="email" expression=""/>
+    <default applyOnUpdate="0" field="website" expression=""/>
   </defaults>
   <constraints>
-    <constraint constraints="3" field="T_Id" unique_strength="1" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="1" field="T_basket" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="0" field="T_Ili_Tid" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="idzad" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="1" field="akind" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="1" field="aname" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="0" field="telefon" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="email" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="website" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="1" constraints="2" field="T_Ili_Tid" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="idzad" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="akind" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="aname" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="telefon" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="email" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="website" notnull_strength="0" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="T_Id" desc=""/>
@@ -179,7 +185,7 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Allgemein *" columnCount="2" groupBox="0" showLabel="1">
+    <attributeEditorContainer name="Allgemein *" visibilityExpression="" columnCount="2" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
       <attributeEditorField name="aname" index="5" showLabel="1"/>
       <attributeEditorField name="idzad" index="3" showLabel="1"/>
       <attributeEditorField name="akind" index="4" showLabel="1"/>
@@ -187,11 +193,35 @@ def my_form_open(dialog, layer, feature):
       <attributeEditorField name="telefon" index="6" showLabel="1"/>
       <attributeEditorField name="website" index="8" showLabel="1"/>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="Adresse" columnCount="1" groupBox="0" showLabel="1">
-      <attributeEditorRelation forceSuppressFormPopup="0" name="address_lg_glssts_vssts_cntact_address_lg_geolssts_v2geolassets_contact_T_Id" label="" relationWidgetTypeId="linking_relation_editor" nmRelationId="one_to_one" showLabel="0" relation="address_lg_glssts_vssts_cntact_address_lg_geolssts_v2geolassets_contact_T_Id">
+    <attributeEditorContainer name="Adresse" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorRelation name="address_lg_glssts_vssts_cntact_address_lg_geolssts_v2geolassets_contact_T_Id" nmRelationId="one_to_one" label="" relation="address_lg_glssts_vssts_cntact_address_lg_geolssts_v2geolassets_contact_T_Id" relationWidgetTypeId="linking_relation_editor" forceSuppressFormPopup="0" showLabel="0">
         <editor_configuration type="Map">
           <Option name="buttons" type="QString" value="AddChildFeature|DeleteChildFeature"/>
           <Option name="one_to_one" type="bool" value="true"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
+    <attributeEditorContainer name="Supplied Assets" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorRelation name="assetitem_contact_supplier_supplier_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" nmRelationId="" label="" relation="assetitem_contact_supplier_supplier_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="0">
+        <editor_configuration type="Map">
+          <Option name="buttons" type="QString" value="NoButton"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
+    <attributeEditorContainer name="Initiated Assets" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorRelation name="assetitem_contact_initiator_initiator_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" nmRelationId="" label="" relation="assetitem_contact_initiator_initiator_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="0">
+        <editor_configuration type="Map">
+          <Option name="buttons" type="QString" value="NoButton"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
+    <attributeEditorContainer name="Authored Assets" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorRelation name="assetitem_contact_author_author_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" nmRelationId="" label="" relation="assetitem_contact_author_author_lg_geolssts_v2geolassets_contact_lg_geolssts_v2geolassets_contact_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="0">
+        <editor_configuration type="Map">
+          <Option name="buttons" type="QString" value="NoButton"/>
           <Option name="show_first_feature" type="bool" value="true"/>
         </editor_configuration>
       </attributeEditorRelation>
@@ -220,15 +250,15 @@ def my_form_open(dialog, layer, feature):
     <field name="website" labelOnTop="0"/>
   </labelOnTop>
   <reuseLastValue>
-    <field name="T_Id" reuseLastValue="0"/>
-    <field name="T_Ili_Tid" reuseLastValue="0"/>
-    <field name="T_basket" reuseLastValue="0"/>
-    <field name="akind" reuseLastValue="0"/>
-    <field name="aname" reuseLastValue="0"/>
-    <field name="email" reuseLastValue="0"/>
-    <field name="idzad" reuseLastValue="0"/>
-    <field name="telefon" reuseLastValue="0"/>
-    <field name="website" reuseLastValue="0"/>
+    <field reuseLastValue="0" name="T_Id"/>
+    <field reuseLastValue="0" name="T_Ili_Tid"/>
+    <field reuseLastValue="0" name="T_basket"/>
+    <field reuseLastValue="0" name="akind"/>
+    <field reuseLastValue="0" name="aname"/>
+    <field reuseLastValue="0" name="email"/>
+    <field reuseLastValue="0" name="idzad"/>
+    <field reuseLastValue="0" name="telefon"/>
+    <field reuseLastValue="0" name="website"/>
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets>

--- a/lg_geolassets_v2/layerstyle/internalproject.qml
+++ b/lg_geolassets_v2/layerstyle/internalproject.qml
@@ -1,108 +1,111 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="Fields|Forms" version="3.25.0-Master">
+<qgis styleCategories="Fields|Forms" version="3.24.3-Tisler">
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id">
+    <field name="T_Id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_basket">
+    <field name="T_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="false" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="&quot;topic&quot; = 'LG_GeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" type="QString" name="ReferencedLayerId"/>
-            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="internalproject_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="ChainFilters" type="bool" value="false"/>
+            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; = 'LG_GeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c"/>
+            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="internalproject_T_basket_T_ILI2DB_BASKET_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_Ili_Tid">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field configurationFlags="None" name="aname">
+    <field name="T_Ili_Tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription">
+    <field name="aname" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="datedelivered">
+    <field name="adescription" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="datedelivered" configurationFlags="None">
       <editWidget type="DateTime">
         <config>
           <Option type="Map">
-            <Option value="true" type="bool" name="allow_null"/>
-            <Option value="true" type="bool" name="calendar_popup"/>
-            <Option value="dd.MM.yy" type="QString" name="display_format"/>
-            <Option value="dd.MM.yy" type="QString" name="field_format"/>
-            <Option value="false" type="bool" name="field_iso_format"/>
+            <Option name="allow_null" type="bool" value="true"/>
+            <Option name="calendar_popup" type="bool" value="true"/>
+            <Option name="display_format" type="QString" value="dd.MM.yy"/>
+            <Option name="field_format" type="QString" value="dd.MM.yy"/>
+            <Option name="field_iso_format" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="T_Id" index="0" name=""/>
-    <alias field="T_basket" index="1" name=""/>
-    <alias field="T_Ili_Tid" index="2" name=""/>
-    <alias field="aname" index="3" name="Name"/>
-    <alias field="adescription" index="4" name="Beschreibung"/>
-    <alias field="datedelivered" index="5" name="Datum der Abgabe des Assets"/>
+    <alias name="" index="0" field="T_Id"/>
+    <alias name="" index="1" field="T_basket"/>
+    <alias name="" index="2" field="T_Ili_Tid"/>
+    <alias name="Name" index="3" field="aname"/>
+    <alias name="Beschreibung" index="4" field="adescription"/>
+    <alias name="Datum der Abgabe des Assets" index="5" field="datedelivered"/>
   </aliases>
   <defaults>
-    <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
-    <default field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets" applyOnUpdate="0"/>
-    <default field="T_Ili_Tid" expression="substr(uuid(), 2, 36)" applyOnUpdate="0"/>
-    <default field="aname" expression="" applyOnUpdate="0"/>
-    <default field="adescription" expression="" applyOnUpdate="0"/>
-    <default field="datedelivered" expression="" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
+    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
+    <default applyOnUpdate="0" field="T_Ili_Tid" expression="substr(uuid(), 2, 36)"/>
+    <default applyOnUpdate="0" field="aname" expression=""/>
+    <default applyOnUpdate="0" field="adescription" expression=""/>
+    <default applyOnUpdate="0" field="datedelivered" expression=""/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" notnull_strength="1" field="T_Id" exp_strength="0" constraints="3"/>
-    <constraint unique_strength="0" notnull_strength="1" field="T_basket" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="T_Ili_Tid" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="1" field="aname" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="datedelivered" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="1" constraints="2" field="T_Ili_Tid" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="aname" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="adescription" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="datedelivered" notnull_strength="0" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="T_Id" desc="" exp=""/>
-    <constraint field="T_basket" desc="" exp=""/>
-    <constraint field="T_Ili_Tid" desc="" exp=""/>
-    <constraint field="aname" desc="" exp=""/>
-    <constraint field="adescription" desc="" exp=""/>
-    <constraint field="datedelivered" desc="" exp=""/>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="T_Ili_Tid" desc=""/>
+    <constraint exp="" field="aname" desc=""/>
+    <constraint exp="" field="adescription" desc=""/>
+    <constraint exp="" field="datedelivered" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <editform tolerant="1"></editform>
@@ -127,9 +130,19 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField showLabel="1" name="aname" index="3"/>
-    <attributeEditorField showLabel="1" name="adescription" index="4"/>
-    <attributeEditorField showLabel="1" name="datedelivered" index="5"/>
+    <attributeEditorContainer name="Allgemein *" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorField name="aname" index="3" showLabel="1"/>
+      <attributeEditorField name="adescription" index="4" showLabel="1"/>
+      <attributeEditorField name="datedelivered" index="5" showLabel="1"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer name="Assets" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorRelation name="assetitem_usedby_usedby_internalproject_T_Id" nmRelationId="" label="" relation="assetitem_usedby_usedby_internalproject_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="0">
+        <editor_configuration type="Map">
+          <Option name="buttons" type="QString" value="NoButton"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
     <field name="T_Id" editable="1"/>
@@ -140,12 +153,12 @@ def my_form_open(dialog, layer, feature):
     <field name="datedelivered" editable="1"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="T_Id"/>
-    <field labelOnTop="0" name="T_Ili_Tid"/>
-    <field labelOnTop="0" name="T_basket"/>
-    <field labelOnTop="0" name="adescription"/>
-    <field labelOnTop="0" name="aname"/>
-    <field labelOnTop="0" name="datedelivered"/>
+    <field name="T_Id" labelOnTop="0"/>
+    <field name="T_Ili_Tid" labelOnTop="0"/>
+    <field name="T_basket" labelOnTop="0"/>
+    <field name="adescription" labelOnTop="0"/>
+    <field name="aname" labelOnTop="0"/>
+    <field name="datedelivered" labelOnTop="0"/>
   </labelOnTop>
   <reuseLastValue>
     <field reuseLastValue="0" name="T_Id"/>
@@ -159,7 +172,7 @@ def my_form_open(dialog, layer, feature):
   <widgets>
     <widget name="assetitem_usedby_usedby_internalproject_T_Id">
       <config type="Map">
-        <Option value="assetitem_usedby_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="nm-rel"/>
+        <Option name="nm-rel" type="QString" value="assetitem_usedby_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
       </config>
     </widget>
   </widgets>

--- a/lg_geolassets_v2/layerstyle/mancatlabelitem.qml
+++ b/lg_geolassets_v2/layerstyle/mancatlabelitem.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="1" styleCategories="LayerConfiguration|Fields|Forms" version="3.24.3-Tisler">
+<qgis readOnly="1" version="3.24.3-Tisler" styleCategories="LayerConfiguration|Fields|Forms">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -18,14 +18,14 @@
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="true"/>
-            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; = 'GeolAssetsCatalogues_V2.Catalogues' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
+            <Option name="AllowAddFeatures" value="false" type="bool"/>
+            <Option name="AllowNULL" value="true" type="bool"/>
+            <Option name="FilterExpression" value="&quot;topic&quot; = 'GeolAssetsCatalogues_V2.Catalogues' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString"/>
             <Option name="FilterFields" type="invalid"/>
-            <Option name="OrderByValue" type="bool" value="true"/>
-            <Option name="Relation" type="QString" value="assetkinditem_T_basket_T_ILI2DB_BASKET_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="false"/>
+            <Option name="OrderByValue" value="true" type="bool"/>
+            <Option name="Relation" value="assetkinditem_T_basket_T_ILI2DB_BASKET_T_Id" type="QString"/>
+            <Option name="ShowForm" value="false" type="bool"/>
+            <Option name="ShowOpenFormButton" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -62,8 +62,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -72,8 +72,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -82,8 +82,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -92,8 +92,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -102,8 +102,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -119,8 +119,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -129,8 +129,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -153,8 +153,8 @@
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option name="IsMultiline" value="false" type="bool"/>
+            <Option name="UseHtml" value="false" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -173,28 +173,7 @@
         </config>
       </editWidget>
     </field>
-    <field name="parent_statusworkitem" configurationFlags="None">
-      <editWidget type="RelationReference">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="parent_assetkinditem" configurationFlags="None">
-      <editWidget type="RelationReference">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="parent_languageitem" configurationFlags="None">
-      <editWidget type="RelationReference">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="parent_natrelitem" configurationFlags="None">
+    <field name="parent_contactkinditem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
@@ -215,21 +194,14 @@
         </config>
       </editWidget>
     </field>
-    <field name="parent_contactkinditem" configurationFlags="None">
+    <field name="parent_geomqualityitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="parent_assetformatitem" configurationFlags="None">
-      <editWidget type="RelationReference">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="parent_statusassetuseitem" configurationFlags="None">
+    <field name="parent_natrelitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
@@ -243,7 +215,28 @@
         </config>
       </editWidget>
     </field>
-    <field name="parent_geomqualityitem" configurationFlags="None">
+    <field name="parent_assetkinditem" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="parent_statusworkitem" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="parent_languageitem" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="parent_statusassetuseitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
@@ -251,6 +244,13 @@
       </editWidget>
     </field>
     <field name="parent_autoobjectcatitem" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="parent_assetformatitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
@@ -285,87 +285,87 @@
     <alias name="" field="adescription_en" index="16"/>
     <alias name="IsSuperItem" field="issuperitem" index="17"/>
     <alias name="IsUseable" field="isuseable" index="18"/>
-    <alias name="Parent" field="parent_statusworkitem" index="19"/>
-    <alias name="Parent" field="parent_assetkinditem" index="20"/>
-    <alias name="Parent" field="parent_languageitem" index="21"/>
-    <alias name="Parent" field="parent_natrelitem" index="22"/>
-    <alias name="Parent" field="parent_mancatlabelitem" index="23"/>
-    <alias name="Parent" field="parent_autocatlabelitem" index="24"/>
-    <alias name="Parent" field="parent_contactkinditem" index="25"/>
-    <alias name="Parent" field="parent_assetformatitem" index="26"/>
-    <alias name="Parent" field="parent_statusassetuseitem" index="27"/>
-    <alias name="Parent" field="parent_legaldocitem" index="28"/>
-    <alias name="Parent" field="parent_geomqualityitem" index="29"/>
-    <alias name="Parent" field="parent_autoobjectcatitem" index="30"/>
+    <alias name="Parent" field="parent_contactkinditem" index="19"/>
+    <alias name="Parent" field="parent_mancatlabelitem" index="20"/>
+    <alias name="Parent" field="parent_autocatlabelitem" index="21"/>
+    <alias name="Parent" field="parent_geomqualityitem" index="22"/>
+    <alias name="Parent" field="parent_natrelitem" index="23"/>
+    <alias name="Parent" field="parent_legaldocitem" index="24"/>
+    <alias name="Parent" field="parent_assetkinditem" index="25"/>
+    <alias name="Parent" field="parent_statusworkitem" index="26"/>
+    <alias name="Parent" field="parent_languageitem" index="27"/>
+    <alias name="Parent" field="parent_statusassetuseitem" index="28"/>
+    <alias name="Parent" field="parent_autoobjectcatitem" index="29"/>
+    <alias name="Parent" field="parent_assetformatitem" index="30"/>
     <alias name="Parent" field="parent_pubchannelitem" index="31"/>
   </aliases>
   <defaults>
-    <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
-    <default field="T_basket" expression="@default_basket_geolassetscatalogues_v2_catalogues" applyOnUpdate="0"/>
-    <default field="T_Ili_Tid" expression="substr(uuid(), 2, 36)" applyOnUpdate="0"/>
-    <default field="acode" expression="" applyOnUpdate="0"/>
-    <default field="geolcode" expression="" applyOnUpdate="0"/>
-    <default field="aname" expression="" applyOnUpdate="0"/>
-    <default field="aname_de" expression="" applyOnUpdate="0"/>
-    <default field="aname_fr" expression="" applyOnUpdate="0"/>
-    <default field="aname_rm" expression="" applyOnUpdate="0"/>
-    <default field="aname_it" expression="" applyOnUpdate="0"/>
-    <default field="aname_en" expression="" applyOnUpdate="0"/>
-    <default field="adescription" expression="" applyOnUpdate="0"/>
-    <default field="adescription_de" expression="" applyOnUpdate="0"/>
-    <default field="adescription_fr" expression="" applyOnUpdate="0"/>
-    <default field="adescription_rm" expression="" applyOnUpdate="0"/>
-    <default field="adescription_it" expression="" applyOnUpdate="0"/>
-    <default field="adescription_en" expression="" applyOnUpdate="0"/>
-    <default field="issuperitem" expression="" applyOnUpdate="0"/>
-    <default field="isuseable" expression="" applyOnUpdate="0"/>
-    <default field="parent_statusworkitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_assetkinditem" expression="" applyOnUpdate="0"/>
-    <default field="parent_languageitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_natrelitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_mancatlabelitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_autocatlabelitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_contactkinditem" expression="" applyOnUpdate="0"/>
-    <default field="parent_assetformatitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_statusassetuseitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_legaldocitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_geomqualityitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_autoobjectcatitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_pubchannelitem" expression="" applyOnUpdate="0"/>
+    <default expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" field="T_Id" applyOnUpdate="0"/>
+    <default expression="@default_basket_geolassetscatalogues_v2_catalogues" field="T_basket" applyOnUpdate="0"/>
+    <default expression="substr(uuid(), 2, 36)" field="T_Ili_Tid" applyOnUpdate="0"/>
+    <default expression="" field="acode" applyOnUpdate="0"/>
+    <default expression="" field="geolcode" applyOnUpdate="0"/>
+    <default expression="" field="aname" applyOnUpdate="0"/>
+    <default expression="" field="aname_de" applyOnUpdate="0"/>
+    <default expression="" field="aname_fr" applyOnUpdate="0"/>
+    <default expression="" field="aname_rm" applyOnUpdate="0"/>
+    <default expression="" field="aname_it" applyOnUpdate="0"/>
+    <default expression="" field="aname_en" applyOnUpdate="0"/>
+    <default expression="" field="adescription" applyOnUpdate="0"/>
+    <default expression="" field="adescription_de" applyOnUpdate="0"/>
+    <default expression="" field="adescription_fr" applyOnUpdate="0"/>
+    <default expression="" field="adescription_rm" applyOnUpdate="0"/>
+    <default expression="" field="adescription_it" applyOnUpdate="0"/>
+    <default expression="" field="adescription_en" applyOnUpdate="0"/>
+    <default expression="" field="issuperitem" applyOnUpdate="0"/>
+    <default expression="" field="isuseable" applyOnUpdate="0"/>
+    <default expression="" field="parent_contactkinditem" applyOnUpdate="0"/>
+    <default expression="" field="parent_mancatlabelitem" applyOnUpdate="0"/>
+    <default expression="" field="parent_autocatlabelitem" applyOnUpdate="0"/>
+    <default expression="" field="parent_geomqualityitem" applyOnUpdate="0"/>
+    <default expression="" field="parent_natrelitem" applyOnUpdate="0"/>
+    <default expression="" field="parent_legaldocitem" applyOnUpdate="0"/>
+    <default expression="" field="parent_assetkinditem" applyOnUpdate="0"/>
+    <default expression="" field="parent_statusworkitem" applyOnUpdate="0"/>
+    <default expression="" field="parent_languageitem" applyOnUpdate="0"/>
+    <default expression="" field="parent_statusassetuseitem" applyOnUpdate="0"/>
+    <default expression="" field="parent_autoobjectcatitem" applyOnUpdate="0"/>
+    <default expression="" field="parent_assetformatitem" applyOnUpdate="0"/>
+    <default expression="" field="parent_pubchannelitem" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint constraints="3" field="T_Id" unique_strength="1" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="1" field="T_basket" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="0" field="T_Ili_Tid" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="1" field="acode" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="0" field="geolcode" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="aname" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="aname_de" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="aname_fr" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="aname_rm" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="aname_it" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="aname_en" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="adescription" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="adescription_de" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="adescription_fr" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="adescription_rm" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="adescription_it" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="adescription_en" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="1" field="issuperitem" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="1" field="isuseable" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="0" field="parent_statusworkitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_assetkinditem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_languageitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_natrelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_mancatlabelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_autocatlabelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_contactkinditem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_assetformatitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_statusassetuseitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_legaldocitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_geomqualityitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_autoobjectcatitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_pubchannelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint unique_strength="1" field="T_Id" exp_strength="0" notnull_strength="1" constraints="3"/>
+    <constraint unique_strength="0" field="T_basket" exp_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint unique_strength="0" field="T_Ili_Tid" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="acode" exp_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint unique_strength="0" field="geolcode" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="aname" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="aname_de" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="aname_fr" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="aname_rm" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="aname_it" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="aname_en" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="adescription" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="adescription_de" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="adescription_fr" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="adescription_rm" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="adescription_it" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="adescription_en" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="issuperitem" exp_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint unique_strength="0" field="isuseable" exp_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint unique_strength="0" field="parent_contactkinditem" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="parent_mancatlabelitem" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="parent_autocatlabelitem" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="parent_geomqualityitem" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="parent_natrelitem" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="parent_legaldocitem" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="parent_assetkinditem" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="parent_statusworkitem" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="parent_languageitem" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="parent_statusassetuseitem" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="parent_autoobjectcatitem" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="parent_assetformatitem" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="parent_pubchannelitem" exp_strength="0" notnull_strength="0" constraints="0"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="T_Id" desc=""/>
@@ -387,18 +387,18 @@
     <constraint exp="" field="adescription_en" desc=""/>
     <constraint exp="" field="issuperitem" desc=""/>
     <constraint exp="" field="isuseable" desc=""/>
-    <constraint exp="" field="parent_statusworkitem" desc=""/>
-    <constraint exp="" field="parent_assetkinditem" desc=""/>
-    <constraint exp="" field="parent_languageitem" desc=""/>
-    <constraint exp="" field="parent_natrelitem" desc=""/>
+    <constraint exp="" field="parent_contactkinditem" desc=""/>
     <constraint exp="" field="parent_mancatlabelitem" desc=""/>
     <constraint exp="" field="parent_autocatlabelitem" desc=""/>
-    <constraint exp="" field="parent_contactkinditem" desc=""/>
-    <constraint exp="" field="parent_assetformatitem" desc=""/>
-    <constraint exp="" field="parent_statusassetuseitem" desc=""/>
-    <constraint exp="" field="parent_legaldocitem" desc=""/>
     <constraint exp="" field="parent_geomqualityitem" desc=""/>
+    <constraint exp="" field="parent_natrelitem" desc=""/>
+    <constraint exp="" field="parent_legaldocitem" desc=""/>
+    <constraint exp="" field="parent_assetkinditem" desc=""/>
+    <constraint exp="" field="parent_statusworkitem" desc=""/>
+    <constraint exp="" field="parent_languageitem" desc=""/>
+    <constraint exp="" field="parent_statusassetuseitem" desc=""/>
     <constraint exp="" field="parent_autoobjectcatitem" desc=""/>
+    <constraint exp="" field="parent_assetformatitem" desc=""/>
     <constraint exp="" field="parent_pubchannelitem" desc=""/>
   </constraintExpressions>
   <expressionfields/>
@@ -426,17 +426,27 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="English" columnCount="1" groupBox="1" showLabel="1">
-      <attributeEditorField name="aname_en" index="10" showLabel="0"/>
-      <attributeEditorField name="adescription_en" index="16" showLabel="0"/>
+    <attributeEditorContainer name="Info" columnCount="1" showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0">
+      <attributeEditorContainer name="English" columnCount="1" showLabel="1" groupBox="1" visibilityExpression="" visibilityExpressionEnabled="0">
+        <attributeEditorField name="aname_en" showLabel="0" index="10"/>
+        <attributeEditorField name="adescription_en" showLabel="0" index="16"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="French" columnCount="1" showLabel="1" groupBox="1" visibilityExpression="" visibilityExpressionEnabled="0">
+        <attributeEditorField name="aname_fr" showLabel="0" index="7"/>
+        <attributeEditorField name="adescription_fr" showLabel="0" index="13"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="German" columnCount="1" showLabel="1" groupBox="1" visibilityExpression="" visibilityExpressionEnabled="0">
+        <attributeEditorField name="aname_de" showLabel="0" index="6"/>
+        <attributeEditorField name="adescription_de" showLabel="0" index="12"/>
+      </attributeEditorContainer>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="French" columnCount="1" groupBox="1" showLabel="1">
-      <attributeEditorField name="aname_fr" index="7" showLabel="0"/>
-      <attributeEditorField name="adescription_fr" index="13" showLabel="0"/>
-    </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="German" columnCount="1" groupBox="1" showLabel="1">
-      <attributeEditorField name="aname_de" index="6" showLabel="0"/>
-      <attributeEditorField name="adescription_de" index="12" showLabel="0"/>
+    <attributeEditorContainer name="Assets" columnCount="1" showLabel="1" groupBox="0" visibilityExpression="" visibilityExpressionEnabled="0">
+      <attributeEditorRelation name="mancatlabelref_areference_mancatlabelitem_T_Id" forceSuppressFormPopup="0" showLabel="0" label="" relation="mancatlabelref_areference_mancatlabelitem_T_Id" nmRelationId="" relationWidgetTypeId="relation_editor">
+        <editor_configuration type="Map">
+          <Option name="buttons" value="NoButton" type="QString"/>
+          <Option name="show_first_feature" value="true" type="bool"/>
+        </editor_configuration>
+      </attributeEditorRelation>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>

--- a/lg_geolassets_v2/layerstyle/mancatlabelref.qml
+++ b/lg_geolassets_v2/layerstyle/mancatlabelref.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" version="3.24.3-Tisler" styleCategories="LayerConfiguration|Fields|Forms">
+<qgis readOnly="0" version="3.22.11-Białowieża" styleCategories="LayerConfiguration|Fields|Forms">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -7,114 +7,114 @@
     <Private>0</Private>
   </flags>
   <fieldConfiguration>
-    <field name="T_Id" configurationFlags="None">
+    <field configurationFlags="None" name="T_Id">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="T_basket" configurationFlags="None">
+    <field configurationFlags="None" name="T_basket">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" value="false" type="bool"/>
-            <Option name="AllowNULL" value="true" type="bool"/>
-            <Option name="ChainFilters" value="false" type="bool"/>
-            <Option name="FilterExpression" value="&quot;topic&quot; = 'GeolAssetsCatalogues_V2.Catalogues' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString"/>
-            <Option name="FilterFields"/>
-            <Option name="MapIdentification" value="false" type="bool"/>
-            <Option name="OrderByValue" value="true" type="bool"/>
-            <Option name="ReadOnly" value="false" type="bool"/>
-            <Option name="ReferencedLayerDataSource" value="/home/cheapdave/qgis_projects/bakery/data.gpkg|layername=T_ILI2DB_BASKET" type="QString"/>
-            <Option name="ReferencedLayerId" value="T_ILI2DB_BASKET_8309458c_0b85_4af6_bff9_256c210b9db4" type="QString"/>
-            <Option name="ReferencedLayerName" value="T_ILI2DB_BASKET" type="QString"/>
-            <Option name="ReferencedLayerProviderKey" value="ogr" type="QString"/>
-            <Option name="Relation" value="mancatlabelref_T_basket_T_ILI2DB_BASKET_T_Id" type="QString"/>
-            <Option name="ShowForm" value="false" type="bool"/>
-            <Option name="ShowOpenFormButton" value="false" type="bool"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="true" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="ChainFilters"/>
+            <Option value="&quot;topic&quot; = 'GeolAssetsCatalogues_V2.Catalogues' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString" name="FilterExpression"/>
+            <Option type="invalid" name="FilterFields"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="true" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/bakery/data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="T_ILI2DB_BASKET_8309458c_0b85_4af6_bff9_256c210b9db4" type="QString" name="ReferencedLayerId"/>
+            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="mancatlabelref_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="false" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="T_Ili_Tid" configurationFlags="None">
+    <field configurationFlags="None" name="T_Ili_Tid">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="T_Seq" configurationFlags="None">
+    <field configurationFlags="None" name="T_Seq">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="areference" configurationFlags="None">
+    <field configurationFlags="None" name="areference">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowNULL" value="true" type="bool"/>
-            <Option name="FilterExpression" value="" type="QString"/>
-            <Option name="FilterFields"/>
-            <Option name="OrderByValue" value="true" type="bool"/>
-            <Option name="Relation" value="mancatlabelref_areference_mancatlabelitem_T_Id" type="QString"/>
-            <Option name="ShowForm" value="false" type="bool"/>
-            <Option name="ShowOpenFormButton" value="false" type="bool"/>
+            <Option value="true" type="bool" name="AllowNULL"/>
+            <Option value="" type="QString" name="FilterExpression"/>
+            <Option type="invalid" name="FilterFields"/>
+            <Option value="true" type="bool" name="OrderByValue"/>
+            <Option value="mancatlabelref_areference_mancatlabelitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="false" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="assetitem_mancatlabel" configurationFlags="None">
+    <field configurationFlags="None" name="assetitem_mancatlabel">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" value="true" type="bool"/>
-            <Option name="AllowNULL" value="true" type="bool"/>
-            <Option name="MapIdentification" value="false" type="bool"/>
-            <Option name="OrderByValue" value="true" type="bool"/>
-            <Option name="ReadOnly" value="false" type="bool"/>
-            <Option name="ReferencedLayerDataSource" value="/home/cheapdave/qgis_projects/bakery/data.gpkg|layername=assetitem" type="QString"/>
-            <Option name="ReferencedLayerId" value="AssetItem_ee0b8039_8300_4a26_81b3_cfe925860c56" type="QString"/>
-            <Option name="ReferencedLayerName" value="AssetItem" type="QString"/>
-            <Option name="ReferencedLayerProviderKey" value="ogr" type="QString"/>
-            <Option name="Relation" value="mancatlabelref_assetitem_mancatlabel_assetitem_T_Id" type="QString"/>
-            <Option name="ShowForm" value="false" type="bool"/>
-            <Option name="ShowOpenFormButton" value="false" type="bool"/>
+            <Option value="true" type="bool" name="AllowAddFeatures"/>
+            <Option value="true" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="true" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/bakery/data.gpkg|layername=assetitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="AssetItem_ee0b8039_8300_4a26_81b3_cfe925860c56" type="QString" name="ReferencedLayerId"/>
+            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="mancatlabelref_assetitem_mancatlabel_assetitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="false" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="lg_glssts_vssts_ssttem_mancatlabel" configurationFlags="None">
+    <field configurationFlags="None" name="lg_glssts_vssts_ssttem_mancatlabel">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" value="true" type="bool"/>
-            <Option name="AllowNULL" value="false" type="bool"/>
-            <Option name="MapIdentification" value="false" type="bool"/>
-            <Option name="OrderByValue" value="false" type="bool"/>
-            <Option name="ReadOnly" value="false" type="bool"/>
-            <Option name="ReferencedLayerDataSource" value="/home/cheapdave/qgis_projects/bakery/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString"/>
-            <Option name="ReferencedLayerId" value="AssetItem_ec3e7b92_b79f_4585_be9a_cbe2b53f3e6f" type="QString"/>
-            <Option name="ReferencedLayerName" value="AssetItem" type="QString"/>
-            <Option name="ReferencedLayerProviderKey" value="ogr" type="QString"/>
-            <Option name="Relation" value="mancatlabelref_lg_glssts_vssts_ssttem_mancatlabel_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString"/>
-            <Option name="ShowForm" value="false" type="bool"/>
-            <Option name="ShowOpenFormButton" value="true" type="bool"/>
+            <Option value="true" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/bakery/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="AssetItem_ec3e7b92_b79f_4585_be9a_cbe2b53f3e6f" type="QString" name="ReferencedLayerId"/>
+            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="mancatlabelref_lg_glssts_vssts_ssttem_mancatlabel_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" field="T_Id" index="0"/>
-    <alias name="" field="T_basket" index="1"/>
-    <alias name="" field="T_Ili_Tid" index="2"/>
-    <alias name="" field="T_Seq" index="3"/>
-    <alias name="Reference" field="areference" index="4"/>
-    <alias name="ManCatLabel" field="assetitem_mancatlabel" index="5"/>
-    <alias name="ManCatLabel" field="lg_glssts_vssts_ssttem_mancatlabel" index="6"/>
+    <alias field="T_Id" index="0" name=""/>
+    <alias field="T_basket" index="1" name=""/>
+    <alias field="T_Ili_Tid" index="2" name=""/>
+    <alias field="T_Seq" index="3" name=""/>
+    <alias field="areference" index="4" name="Reference"/>
+    <alias field="assetitem_mancatlabel" index="5" name="ManCatLabel"/>
+    <alias field="lg_glssts_vssts_ssttem_mancatlabel" index="6" name="ManCatLabel"/>
   </aliases>
   <defaults>
     <default expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" field="T_Id" applyOnUpdate="0"/>
@@ -126,13 +126,13 @@
     <default expression="" field="lg_glssts_vssts_ssttem_mancatlabel" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" field="T_Id" exp_strength="0" notnull_strength="1" constraints="3"/>
-    <constraint unique_strength="0" field="T_basket" exp_strength="0" notnull_strength="1" constraints="1"/>
-    <constraint unique_strength="0" field="T_Ili_Tid" exp_strength="0" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" field="T_Seq" exp_strength="0" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" field="areference" exp_strength="0" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" field="assetitem_mancatlabel" exp_strength="0" notnull_strength="0" constraints="0"/>
-    <constraint unique_strength="0" field="lg_glssts_vssts_ssttem_mancatlabel" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="T_Id" exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3"/>
+    <constraint field="T_basket" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint field="T_Ili_Tid" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="T_Seq" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="areference" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="assetitem_mancatlabel" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="lg_glssts_vssts_ssttem_mancatlabel" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="T_Id" desc=""/>
@@ -168,37 +168,38 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField name="lg_glssts_vssts_ssttem_mancatlabel" showLabel="1" index="6"/>
+    <attributeEditorField index="6" showLabel="1" name="lg_glssts_vssts_ssttem_mancatlabel"/>
   </attributeEditorForm>
   <editable>
-    <field name="T_Id" editable="1"/>
-    <field name="T_Ili_Tid" editable="1"/>
-    <field name="T_Seq" editable="1"/>
-    <field name="T_basket" editable="1"/>
-    <field name="areference" editable="1"/>
-    <field name="assetitem_mancatlabel" editable="1"/>
-    <field name="lg_glssts_vssts_ssttem_mancatlabel" editable="1"/>
+    <field editable="1" name="T_Id"/>
+    <field editable="1" name="T_Ili_Tid"/>
+    <field editable="1" name="T_Seq"/>
+    <field editable="1" name="T_basket"/>
+    <field editable="1" name="areference"/>
+    <field editable="1" name="assetitem_mancatlabel"/>
+    <field editable="1" name="lg_glssts_vssts_ssttem_mancatlabel"/>
   </editable>
   <labelOnTop>
-    <field name="T_Id" labelOnTop="0"/>
-    <field name="T_Ili_Tid" labelOnTop="0"/>
-    <field name="T_Seq" labelOnTop="0"/>
-    <field name="T_basket" labelOnTop="0"/>
-    <field name="areference" labelOnTop="0"/>
-    <field name="assetitem_mancatlabel" labelOnTop="0"/>
-    <field name="lg_glssts_vssts_ssttem_mancatlabel" labelOnTop="0"/>
+    <field labelOnTop="0" name="T_Id"/>
+    <field labelOnTop="0" name="T_Ili_Tid"/>
+    <field labelOnTop="0" name="T_Seq"/>
+    <field labelOnTop="0" name="T_basket"/>
+    <field labelOnTop="0" name="areference"/>
+    <field labelOnTop="0" name="assetitem_mancatlabel"/>
+    <field labelOnTop="0" name="lg_glssts_vssts_ssttem_mancatlabel"/>
   </labelOnTop>
   <reuseLastValue>
-    <field name="T_Id" reuseLastValue="0"/>
-    <field name="T_Ili_Tid" reuseLastValue="0"/>
-    <field name="T_Seq" reuseLastValue="0"/>
-    <field name="T_basket" reuseLastValue="0"/>
-    <field name="areference" reuseLastValue="0"/>
-    <field name="assetitem_mancatlabel" reuseLastValue="0"/>
-    <field name="lg_glssts_vssts_ssttem_mancatlabel" reuseLastValue="0"/>
+    <field reuseLastValue="0" name="T_Id"/>
+    <field reuseLastValue="0" name="T_Ili_Tid"/>
+    <field reuseLastValue="0" name="T_Seq"/>
+    <field reuseLastValue="0" name="T_basket"/>
+    <field reuseLastValue="0" name="areference"/>
+    <field reuseLastValue="0" name="assetitem_mancatlabel"/>
+    <field reuseLastValue="0" name="lg_glssts_vssts_ssttem_mancatlabel"/>
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>
-  <previewExpression>attribute(get_feature('AssetItem', 'T_Id',"lg_glssts_vssts_ssttem_mancatlabel" ),'titleoriginal')</previewExpression>
+  <previewExpression>coalesce( attribute(get_feature('AssetItem', 'T_Id', "lg_glssts_vssts_ssttem_mancatlabel"),'titlepublic'),'Kein Öffentlicher Titel vorhanden' )
+</previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/layerstyle/mancatlabelref.qml
+++ b/lg_geolassets_v2/layerstyle/mancatlabelref.qml
@@ -1,0 +1,204 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis readOnly="0" version="3.24.3-Tisler" styleCategories="LayerConfiguration|Fields|Forms">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
+  <fieldConfiguration>
+    <field name="T_Id" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="T_basket" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" value="false" type="bool"/>
+            <Option name="AllowNULL" value="true" type="bool"/>
+            <Option name="ChainFilters" value="false" type="bool"/>
+            <Option name="FilterExpression" value="&quot;topic&quot; = 'GeolAssetsCatalogues_V2.Catalogues' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString"/>
+            <Option name="FilterFields"/>
+            <Option name="MapIdentification" value="false" type="bool"/>
+            <Option name="OrderByValue" value="true" type="bool"/>
+            <Option name="ReadOnly" value="false" type="bool"/>
+            <Option name="ReferencedLayerDataSource" value="/home/cheapdave/qgis_projects/bakery/data.gpkg|layername=T_ILI2DB_BASKET" type="QString"/>
+            <Option name="ReferencedLayerId" value="T_ILI2DB_BASKET_8309458c_0b85_4af6_bff9_256c210b9db4" type="QString"/>
+            <Option name="ReferencedLayerName" value="T_ILI2DB_BASKET" type="QString"/>
+            <Option name="ReferencedLayerProviderKey" value="ogr" type="QString"/>
+            <Option name="Relation" value="mancatlabelref_T_basket_T_ILI2DB_BASKET_T_Id" type="QString"/>
+            <Option name="ShowForm" value="false" type="bool"/>
+            <Option name="ShowOpenFormButton" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="T_Ili_Tid" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="T_Seq" configurationFlags="None">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="areference" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowNULL" value="true" type="bool"/>
+            <Option name="FilterExpression" value="" type="QString"/>
+            <Option name="FilterFields"/>
+            <Option name="OrderByValue" value="true" type="bool"/>
+            <Option name="Relation" value="mancatlabelref_areference_mancatlabelitem_T_Id" type="QString"/>
+            <Option name="ShowForm" value="false" type="bool"/>
+            <Option name="ShowOpenFormButton" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="assetitem_mancatlabel" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" value="true" type="bool"/>
+            <Option name="AllowNULL" value="true" type="bool"/>
+            <Option name="MapIdentification" value="false" type="bool"/>
+            <Option name="OrderByValue" value="true" type="bool"/>
+            <Option name="ReadOnly" value="false" type="bool"/>
+            <Option name="ReferencedLayerDataSource" value="/home/cheapdave/qgis_projects/bakery/data.gpkg|layername=assetitem" type="QString"/>
+            <Option name="ReferencedLayerId" value="AssetItem_ee0b8039_8300_4a26_81b3_cfe925860c56" type="QString"/>
+            <Option name="ReferencedLayerName" value="AssetItem" type="QString"/>
+            <Option name="ReferencedLayerProviderKey" value="ogr" type="QString"/>
+            <Option name="Relation" value="mancatlabelref_assetitem_mancatlabel_assetitem_T_Id" type="QString"/>
+            <Option name="ShowForm" value="false" type="bool"/>
+            <Option name="ShowOpenFormButton" value="false" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="lg_glssts_vssts_ssttem_mancatlabel" configurationFlags="None">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" value="true" type="bool"/>
+            <Option name="AllowNULL" value="false" type="bool"/>
+            <Option name="MapIdentification" value="false" type="bool"/>
+            <Option name="OrderByValue" value="false" type="bool"/>
+            <Option name="ReadOnly" value="false" type="bool"/>
+            <Option name="ReferencedLayerDataSource" value="/home/cheapdave/qgis_projects/bakery/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString"/>
+            <Option name="ReferencedLayerId" value="AssetItem_ec3e7b92_b79f_4585_be9a_cbe2b53f3e6f" type="QString"/>
+            <Option name="ReferencedLayerName" value="AssetItem" type="QString"/>
+            <Option name="ReferencedLayerProviderKey" value="ogr" type="QString"/>
+            <Option name="Relation" value="mancatlabelref_lg_glssts_vssts_ssttem_mancatlabel_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString"/>
+            <Option name="ShowForm" value="false" type="bool"/>
+            <Option name="ShowOpenFormButton" value="true" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias name="" field="T_Id" index="0"/>
+    <alias name="" field="T_basket" index="1"/>
+    <alias name="" field="T_Ili_Tid" index="2"/>
+    <alias name="" field="T_Seq" index="3"/>
+    <alias name="Reference" field="areference" index="4"/>
+    <alias name="ManCatLabel" field="assetitem_mancatlabel" index="5"/>
+    <alias name="ManCatLabel" field="lg_glssts_vssts_ssttem_mancatlabel" index="6"/>
+  </aliases>
+  <defaults>
+    <default expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" field="T_Id" applyOnUpdate="0"/>
+    <default expression="@default_basket_geolassetscatalogues_v2_catalogues" field="T_basket" applyOnUpdate="0"/>
+    <default expression="substr(uuid(), 2, 36)" field="T_Ili_Tid" applyOnUpdate="0"/>
+    <default expression="" field="T_Seq" applyOnUpdate="0"/>
+    <default expression="" field="areference" applyOnUpdate="0"/>
+    <default expression="" field="assetitem_mancatlabel" applyOnUpdate="0"/>
+    <default expression="" field="lg_glssts_vssts_ssttem_mancatlabel" applyOnUpdate="0"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="1" field="T_Id" exp_strength="0" notnull_strength="1" constraints="3"/>
+    <constraint unique_strength="0" field="T_basket" exp_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint unique_strength="0" field="T_Ili_Tid" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="T_Seq" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="areference" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="assetitem_mancatlabel" exp_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint unique_strength="0" field="lg_glssts_vssts_ssttem_mancatlabel" exp_strength="0" notnull_strength="0" constraints="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="T_Ili_Tid" desc=""/>
+    <constraint exp="" field="T_Seq" desc=""/>
+    <constraint exp="" field="areference" desc=""/>
+    <constraint exp="" field="assetitem_mancatlabel" desc=""/>
+    <constraint exp="" field="lg_glssts_vssts_ssttem_mancatlabel" desc=""/>
+  </constraintExpressions>
+  <expressionfields/>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+    geom = feature.geometry()
+    control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorField name="lg_glssts_vssts_ssttem_mancatlabel" showLabel="1" index="6"/>
+  </attributeEditorForm>
+  <editable>
+    <field name="T_Id" editable="1"/>
+    <field name="T_Ili_Tid" editable="1"/>
+    <field name="T_Seq" editable="1"/>
+    <field name="T_basket" editable="1"/>
+    <field name="areference" editable="1"/>
+    <field name="assetitem_mancatlabel" editable="1"/>
+    <field name="lg_glssts_vssts_ssttem_mancatlabel" editable="1"/>
+  </editable>
+  <labelOnTop>
+    <field name="T_Id" labelOnTop="0"/>
+    <field name="T_Ili_Tid" labelOnTop="0"/>
+    <field name="T_Seq" labelOnTop="0"/>
+    <field name="T_basket" labelOnTop="0"/>
+    <field name="areference" labelOnTop="0"/>
+    <field name="assetitem_mancatlabel" labelOnTop="0"/>
+    <field name="lg_glssts_vssts_ssttem_mancatlabel" labelOnTop="0"/>
+  </labelOnTop>
+  <reuseLastValue>
+    <field name="T_Id" reuseLastValue="0"/>
+    <field name="T_Ili_Tid" reuseLastValue="0"/>
+    <field name="T_Seq" reuseLastValue="0"/>
+    <field name="T_basket" reuseLastValue="0"/>
+    <field name="areference" reuseLastValue="0"/>
+    <field name="assetitem_mancatlabel" reuseLastValue="0"/>
+    <field name="lg_glssts_vssts_ssttem_mancatlabel" reuseLastValue="0"/>
+  </reuseLastValue>
+  <dataDefinedFieldProperties/>
+  <widgets/>
+  <previewExpression>attribute(get_feature('AssetItem', 'T_Id',"lg_glssts_vssts_ssttem_mancatlabel" ),'titleoriginal')</previewExpression>
+  <layerGeometryType>4</layerGeometryType>
+</qgis>

--- a/lg_geolassets_v2/layerstyle/natrelitem.qml
+++ b/lg_geolassets_v2/layerstyle/natrelitem.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="1" styleCategories="LayerConfiguration|Fields|Forms" version="3.24.3-Tisler">
+<qgis styleCategories="LayerConfiguration|Fields|Forms" readOnly="1" version="3.24.3-Tisler">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -266,106 +266,106 @@
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" field="T_Id" index="0"/>
-    <alias name="" field="T_basket" index="1"/>
-    <alias name="" field="T_Ili_Tid" index="2"/>
-    <alias name="Code" field="acode" index="3"/>
-    <alias name="GeolCode" field="geolcode" index="4"/>
-    <alias name="Name" field="aname" index="5"/>
-    <alias name="" field="aname_de" index="6"/>
-    <alias name="" field="aname_fr" index="7"/>
-    <alias name="" field="aname_rm" index="8"/>
-    <alias name="" field="aname_it" index="9"/>
-    <alias name="" field="aname_en" index="10"/>
-    <alias name="Description" field="adescription" index="11"/>
-    <alias name="" field="adescription_de" index="12"/>
-    <alias name="" field="adescription_fr" index="13"/>
-    <alias name="" field="adescription_rm" index="14"/>
-    <alias name="" field="adescription_it" index="15"/>
-    <alias name="" field="adescription_en" index="16"/>
-    <alias name="IsSuperItem" field="issuperitem" index="17"/>
-    <alias name="IsUseable" field="isuseable" index="18"/>
-    <alias name="Parent" field="parent_statusworkitem" index="19"/>
-    <alias name="Parent" field="parent_assetkinditem" index="20"/>
-    <alias name="Parent" field="parent_languageitem" index="21"/>
-    <alias name="Parent" field="parent_natrelitem" index="22"/>
-    <alias name="Parent" field="parent_mancatlabelitem" index="23"/>
-    <alias name="Parent" field="parent_autocatlabelitem" index="24"/>
-    <alias name="Parent" field="parent_contactkinditem" index="25"/>
-    <alias name="Parent" field="parent_assetformatitem" index="26"/>
-    <alias name="Parent" field="parent_statusassetuseitem" index="27"/>
-    <alias name="Parent" field="parent_legaldocitem" index="28"/>
-    <alias name="Parent" field="parent_geomqualityitem" index="29"/>
-    <alias name="Parent" field="parent_autoobjectcatitem" index="30"/>
-    <alias name="Parent" field="parent_pubchannelitem" index="31"/>
+    <alias name="" index="0" field="T_Id"/>
+    <alias name="" index="1" field="T_basket"/>
+    <alias name="" index="2" field="T_Ili_Tid"/>
+    <alias name="Code" index="3" field="acode"/>
+    <alias name="GeolCode" index="4" field="geolcode"/>
+    <alias name="Name" index="5" field="aname"/>
+    <alias name="" index="6" field="aname_de"/>
+    <alias name="" index="7" field="aname_fr"/>
+    <alias name="" index="8" field="aname_rm"/>
+    <alias name="" index="9" field="aname_it"/>
+    <alias name="" index="10" field="aname_en"/>
+    <alias name="Description" index="11" field="adescription"/>
+    <alias name="" index="12" field="adescription_de"/>
+    <alias name="" index="13" field="adescription_fr"/>
+    <alias name="" index="14" field="adescription_rm"/>
+    <alias name="" index="15" field="adescription_it"/>
+    <alias name="" index="16" field="adescription_en"/>
+    <alias name="IsSuperItem" index="17" field="issuperitem"/>
+    <alias name="IsUseable" index="18" field="isuseable"/>
+    <alias name="Parent" index="19" field="parent_statusworkitem"/>
+    <alias name="Parent" index="20" field="parent_assetkinditem"/>
+    <alias name="Parent" index="21" field="parent_languageitem"/>
+    <alias name="Parent" index="22" field="parent_natrelitem"/>
+    <alias name="Parent" index="23" field="parent_mancatlabelitem"/>
+    <alias name="Parent" index="24" field="parent_autocatlabelitem"/>
+    <alias name="Parent" index="25" field="parent_contactkinditem"/>
+    <alias name="Parent" index="26" field="parent_assetformatitem"/>
+    <alias name="Parent" index="27" field="parent_statusassetuseitem"/>
+    <alias name="Parent" index="28" field="parent_legaldocitem"/>
+    <alias name="Parent" index="29" field="parent_geomqualityitem"/>
+    <alias name="Parent" index="30" field="parent_autoobjectcatitem"/>
+    <alias name="Parent" index="31" field="parent_pubchannelitem"/>
   </aliases>
   <defaults>
-    <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
-    <default field="T_basket" expression="@default_basket_lg_geolassetscatalogues_v2_catalogues" applyOnUpdate="0"/>
-    <default field="T_Ili_Tid" expression="substr(uuid(), 2, 36)" applyOnUpdate="0"/>
-    <default field="acode" expression="" applyOnUpdate="0"/>
-    <default field="geolcode" expression="" applyOnUpdate="0"/>
-    <default field="aname" expression="" applyOnUpdate="0"/>
-    <default field="aname_de" expression="" applyOnUpdate="0"/>
-    <default field="aname_fr" expression="" applyOnUpdate="0"/>
-    <default field="aname_rm" expression="" applyOnUpdate="0"/>
-    <default field="aname_it" expression="" applyOnUpdate="0"/>
-    <default field="aname_en" expression="" applyOnUpdate="0"/>
-    <default field="adescription" expression="" applyOnUpdate="0"/>
-    <default field="adescription_de" expression="" applyOnUpdate="0"/>
-    <default field="adescription_fr" expression="" applyOnUpdate="0"/>
-    <default field="adescription_rm" expression="" applyOnUpdate="0"/>
-    <default field="adescription_it" expression="" applyOnUpdate="0"/>
-    <default field="adescription_en" expression="" applyOnUpdate="0"/>
-    <default field="issuperitem" expression="" applyOnUpdate="0"/>
-    <default field="isuseable" expression="" applyOnUpdate="0"/>
-    <default field="parent_statusworkitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_assetkinditem" expression="" applyOnUpdate="0"/>
-    <default field="parent_languageitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_natrelitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_mancatlabelitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_autocatlabelitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_contactkinditem" expression="" applyOnUpdate="0"/>
-    <default field="parent_assetformatitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_statusassetuseitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_legaldocitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_geomqualityitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_autoobjectcatitem" expression="" applyOnUpdate="0"/>
-    <default field="parent_pubchannelitem" expression="" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
+    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassetscatalogues_v2_catalogues"/>
+    <default applyOnUpdate="0" field="T_Ili_Tid" expression="substr(uuid(), 2, 36)"/>
+    <default applyOnUpdate="0" field="acode" expression=""/>
+    <default applyOnUpdate="0" field="geolcode" expression=""/>
+    <default applyOnUpdate="0" field="aname" expression=""/>
+    <default applyOnUpdate="0" field="aname_de" expression=""/>
+    <default applyOnUpdate="0" field="aname_fr" expression=""/>
+    <default applyOnUpdate="0" field="aname_rm" expression=""/>
+    <default applyOnUpdate="0" field="aname_it" expression=""/>
+    <default applyOnUpdate="0" field="aname_en" expression=""/>
+    <default applyOnUpdate="0" field="adescription" expression=""/>
+    <default applyOnUpdate="0" field="adescription_de" expression=""/>
+    <default applyOnUpdate="0" field="adescription_fr" expression=""/>
+    <default applyOnUpdate="0" field="adescription_rm" expression=""/>
+    <default applyOnUpdate="0" field="adescription_it" expression=""/>
+    <default applyOnUpdate="0" field="adescription_en" expression=""/>
+    <default applyOnUpdate="0" field="issuperitem" expression=""/>
+    <default applyOnUpdate="0" field="isuseable" expression=""/>
+    <default applyOnUpdate="0" field="parent_statusworkitem" expression=""/>
+    <default applyOnUpdate="0" field="parent_assetkinditem" expression=""/>
+    <default applyOnUpdate="0" field="parent_languageitem" expression=""/>
+    <default applyOnUpdate="0" field="parent_natrelitem" expression=""/>
+    <default applyOnUpdate="0" field="parent_mancatlabelitem" expression=""/>
+    <default applyOnUpdate="0" field="parent_autocatlabelitem" expression=""/>
+    <default applyOnUpdate="0" field="parent_contactkinditem" expression=""/>
+    <default applyOnUpdate="0" field="parent_assetformatitem" expression=""/>
+    <default applyOnUpdate="0" field="parent_statusassetuseitem" expression=""/>
+    <default applyOnUpdate="0" field="parent_legaldocitem" expression=""/>
+    <default applyOnUpdate="0" field="parent_geomqualityitem" expression=""/>
+    <default applyOnUpdate="0" field="parent_autoobjectcatitem" expression=""/>
+    <default applyOnUpdate="0" field="parent_pubchannelitem" expression=""/>
   </defaults>
   <constraints>
-    <constraint constraints="3" field="T_Id" unique_strength="1" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="1" field="T_basket" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="0" field="T_Ili_Tid" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="1" field="acode" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="0" field="geolcode" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="aname" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="aname_de" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="aname_fr" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="aname_rm" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="aname_it" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="aname_en" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="adescription" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="adescription_de" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="adescription_fr" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="adescription_rm" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="adescription_it" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="adescription_en" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="1" field="issuperitem" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="1" field="isuseable" unique_strength="0" exp_strength="0" notnull_strength="1"/>
-    <constraint constraints="0" field="parent_statusworkitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_assetkinditem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_languageitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_natrelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_mancatlabelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_autocatlabelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_contactkinditem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_assetformatitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_statusassetuseitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_legaldocitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_geomqualityitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_autoobjectcatitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
-    <constraint constraints="0" field="parent_pubchannelitem" unique_strength="0" exp_strength="0" notnull_strength="0"/>
+    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="T_Ili_Tid" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="acode" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="geolcode" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="aname" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="aname_de" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="aname_fr" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="aname_rm" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="aname_it" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="aname_en" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="adescription" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="adescription_de" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="adescription_fr" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="adescription_rm" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="adescription_it" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="adescription_en" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="issuperitem" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="isuseable" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="parent_statusworkitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="parent_assetkinditem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="parent_languageitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="parent_natrelitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="parent_mancatlabelitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="parent_autocatlabelitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="parent_contactkinditem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="parent_assetformatitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="parent_statusassetuseitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="parent_legaldocitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="parent_geomqualityitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="parent_autoobjectcatitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="parent_pubchannelitem" notnull_strength="0" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="T_Id" desc=""/>
@@ -426,17 +426,27 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="English" columnCount="1" groupBox="1" showLabel="1">
-      <attributeEditorField name="aname_en" index="10" showLabel="0"/>
-      <attributeEditorField name="adescription_en" index="16" showLabel="0"/>
+    <attributeEditorContainer name="Info" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorContainer name="English" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
+        <attributeEditorField name="aname_en" index="10" showLabel="0"/>
+        <attributeEditorField name="adescription_en" index="16" showLabel="0"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="German" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
+        <attributeEditorField name="aname_de" index="6" showLabel="0"/>
+        <attributeEditorField name="adescription_de" index="12" showLabel="0"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer name="French" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="1" showLabel="1">
+        <attributeEditorField name="aname_fr" index="7" showLabel="0"/>
+        <attributeEditorField name="adescription_fr" index="13" showLabel="0"/>
+      </attributeEditorContainer>
     </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="French" columnCount="1" groupBox="1" showLabel="1">
-      <attributeEditorField name="aname_fr" index="7" showLabel="0"/>
-      <attributeEditorField name="adescription_fr" index="13" showLabel="0"/>
-    </attributeEditorContainer>
-    <attributeEditorContainer visibilityExpressionEnabled="0" visibilityExpression="" name="German" columnCount="1" groupBox="1" showLabel="1">
-      <attributeEditorField name="aname_de" index="6" showLabel="0"/>
-      <attributeEditorField name="adescription_de" index="12" showLabel="0"/>
+    <attributeEditorContainer name="Assets" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorRelation name="typenatrel_typenatrel_natrelitem_T_Id" nmRelationId="" label="" relation="typenatrel_typenatrel_natrelitem_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="0">
+        <editor_configuration type="Map">
+          <Option name="buttons" type="QString" value="NoButton"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
+        </editor_configuration>
+      </attributeEditorRelation>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
@@ -508,38 +518,38 @@ def my_form_open(dialog, layer, feature):
     <field name="parent_statusworkitem" labelOnTop="0"/>
   </labelOnTop>
   <reuseLastValue>
-    <field name="T_Id" reuseLastValue="0"/>
-    <field name="T_Ili_Tid" reuseLastValue="0"/>
-    <field name="T_basket" reuseLastValue="0"/>
-    <field name="acode" reuseLastValue="0"/>
-    <field name="adescription" reuseLastValue="0"/>
-    <field name="adescription_de" reuseLastValue="0"/>
-    <field name="adescription_en" reuseLastValue="0"/>
-    <field name="adescription_fr" reuseLastValue="0"/>
-    <field name="adescription_it" reuseLastValue="0"/>
-    <field name="adescription_rm" reuseLastValue="0"/>
-    <field name="aname" reuseLastValue="0"/>
-    <field name="aname_de" reuseLastValue="0"/>
-    <field name="aname_en" reuseLastValue="0"/>
-    <field name="aname_fr" reuseLastValue="0"/>
-    <field name="aname_it" reuseLastValue="0"/>
-    <field name="aname_rm" reuseLastValue="0"/>
-    <field name="geolcode" reuseLastValue="0"/>
-    <field name="issuperitem" reuseLastValue="0"/>
-    <field name="isuseable" reuseLastValue="0"/>
-    <field name="parent_assetformatitem" reuseLastValue="0"/>
-    <field name="parent_assetkinditem" reuseLastValue="0"/>
-    <field name="parent_autocatlabelitem" reuseLastValue="0"/>
-    <field name="parent_autoobjectcatitem" reuseLastValue="0"/>
-    <field name="parent_contactkinditem" reuseLastValue="0"/>
-    <field name="parent_geomqualityitem" reuseLastValue="0"/>
-    <field name="parent_languageitem" reuseLastValue="0"/>
-    <field name="parent_legaldocitem" reuseLastValue="0"/>
-    <field name="parent_mancatlabelitem" reuseLastValue="0"/>
-    <field name="parent_natrelitem" reuseLastValue="0"/>
-    <field name="parent_pubchannelitem" reuseLastValue="0"/>
-    <field name="parent_statusassetuseitem" reuseLastValue="0"/>
-    <field name="parent_statusworkitem" reuseLastValue="0"/>
+    <field reuseLastValue="0" name="T_Id"/>
+    <field reuseLastValue="0" name="T_Ili_Tid"/>
+    <field reuseLastValue="0" name="T_basket"/>
+    <field reuseLastValue="0" name="acode"/>
+    <field reuseLastValue="0" name="adescription"/>
+    <field reuseLastValue="0" name="adescription_de"/>
+    <field reuseLastValue="0" name="adescription_en"/>
+    <field reuseLastValue="0" name="adescription_fr"/>
+    <field reuseLastValue="0" name="adescription_it"/>
+    <field reuseLastValue="0" name="adescription_rm"/>
+    <field reuseLastValue="0" name="aname"/>
+    <field reuseLastValue="0" name="aname_de"/>
+    <field reuseLastValue="0" name="aname_en"/>
+    <field reuseLastValue="0" name="aname_fr"/>
+    <field reuseLastValue="0" name="aname_it"/>
+    <field reuseLastValue="0" name="aname_rm"/>
+    <field reuseLastValue="0" name="geolcode"/>
+    <field reuseLastValue="0" name="issuperitem"/>
+    <field reuseLastValue="0" name="isuseable"/>
+    <field reuseLastValue="0" name="parent_assetformatitem"/>
+    <field reuseLastValue="0" name="parent_assetkinditem"/>
+    <field reuseLastValue="0" name="parent_autocatlabelitem"/>
+    <field reuseLastValue="0" name="parent_autoobjectcatitem"/>
+    <field reuseLastValue="0" name="parent_contactkinditem"/>
+    <field reuseLastValue="0" name="parent_geomqualityitem"/>
+    <field reuseLastValue="0" name="parent_languageitem"/>
+    <field reuseLastValue="0" name="parent_legaldocitem"/>
+    <field reuseLastValue="0" name="parent_mancatlabelitem"/>
+    <field reuseLastValue="0" name="parent_natrelitem"/>
+    <field reuseLastValue="0" name="parent_pubchannelitem"/>
+    <field reuseLastValue="0" name="parent_statusassetuseitem"/>
+    <field reuseLastValue="0" name="parent_statusworkitem"/>
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>

--- a/lg_geolassets_v2/layerstyle/publication.qml
+++ b/lg_geolassets_v2/layerstyle/publication.qml
@@ -1,135 +1,138 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="Fields|Forms" version="3.25.0-Master">
+<qgis styleCategories="Fields|Forms" version="3.24.3-Tisler">
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id">
+    <field name="T_Id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_basket">
+    <field name="T_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="false" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="&quot;topic&quot; = 'LG_GeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" type="QString" name="ReferencedLayerId"/>
-            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="publication_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="ChainFilters" type="bool" value="false"/>
+            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; = 'LG_GeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c"/>
+            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="publication_T_basket_T_ILI2DB_BASKET_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_Ili_Tid">
+    <field name="T_Ili_Tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
-          <Option/>
+          <Option type="Map">
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
+          </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="datepublication">
+    <field name="datepublication" configurationFlags="None">
       <editWidget type="DateTime">
         <config>
           <Option type="Map">
-            <Option value="true" type="bool" name="allow_null"/>
-            <Option value="true" type="bool" name="calendar_popup"/>
-            <Option value="dd.MM.yyyy" type="QString" name="display_format"/>
-            <Option value="dd.MM.yy" type="QString" name="field_format"/>
-            <Option value="false" type="bool" name="field_iso_format"/>
+            <Option name="allow_null" type="bool" value="true"/>
+            <Option name="calendar_popup" type="bool" value="true"/>
+            <Option name="display_format" type="QString" value="dd.MM.yyyy"/>
+            <Option name="field_format" type="QString" value="dd.MM.yy"/>
+            <Option name="field_iso_format" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="achannel">
+    <field name="achannel" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=pubchannelitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="PubChannelItem_e2a53909_af60_4f4e_92e5_2e0d6a786597" type="QString" name="ReferencedLayerId"/>
-            <Option value="PubChannelItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="publication_achannel_pubchannelitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="ChainFilters" type="bool" value="false"/>
+            <Option name="FilterExpression" type="QString" value=""/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=pubchannelitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="PubChannelItem_b75a296a_859f_4846_9136_ec5d686c8ee2"/>
+            <Option name="ReferencedLayerName" type="QString" value="PubChannelItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="publication_achannel_pubchannelitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="adescription">
+    <field name="adescription" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="link">
+    <field name="link" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="T_Id" index="0" name=""/>
-    <alias field="T_basket" index="1" name=""/>
-    <alias field="T_Ili_Tid" index="2" name=""/>
-    <alias field="datepublication" index="3" name="Datum"/>
-    <alias field="achannel" index="4" name="Kanal"/>
-    <alias field="adescription" index="5" name="Name des Kanals"/>
-    <alias field="link" index="6" name="URL oder DOI"/>
+    <alias name="" index="0" field="T_Id"/>
+    <alias name="" index="1" field="T_basket"/>
+    <alias name="" index="2" field="T_Ili_Tid"/>
+    <alias name="Datum" index="3" field="datepublication"/>
+    <alias name="Kanal" index="4" field="achannel"/>
+    <alias name="Name des Kanals" index="5" field="adescription"/>
+    <alias name="URL oder DOI" index="6" field="link"/>
   </aliases>
   <defaults>
-    <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
-    <default field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets" applyOnUpdate="0"/>
-    <default field="T_Ili_Tid" expression="substr(uuid(), 2, 36)" applyOnUpdate="0"/>
-    <default field="datepublication" expression="" applyOnUpdate="0"/>
-    <default field="achannel" expression="" applyOnUpdate="0"/>
-    <default field="adescription" expression="" applyOnUpdate="0"/>
-    <default field="link" expression="" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
+    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
+    <default applyOnUpdate="0" field="T_Ili_Tid" expression="substr(uuid(), 2, 36)"/>
+    <default applyOnUpdate="0" field="datepublication" expression=""/>
+    <default applyOnUpdate="0" field="achannel" expression=""/>
+    <default applyOnUpdate="0" field="adescription" expression=""/>
+    <default applyOnUpdate="0" field="link" expression=""/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" notnull_strength="1" field="T_Id" exp_strength="0" constraints="3"/>
-    <constraint unique_strength="0" notnull_strength="1" field="T_basket" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="T_Ili_Tid" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="1" field="datepublication" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="1" field="achannel" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="adescription" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="link" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="1" constraints="2" field="T_Ili_Tid" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="datepublication" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="achannel" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="adescription" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="link" notnull_strength="0" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="T_Id" desc="" exp=""/>
-    <constraint field="T_basket" desc="" exp=""/>
-    <constraint field="T_Ili_Tid" desc="" exp=""/>
-    <constraint field="datepublication" desc="" exp=""/>
-    <constraint field="achannel" desc="" exp=""/>
-    <constraint field="adescription" desc="" exp=""/>
-    <constraint field="link" desc="" exp=""/>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="T_Ili_Tid" desc=""/>
+    <constraint exp="" field="datepublication" desc=""/>
+    <constraint exp="" field="achannel" desc=""/>
+    <constraint exp="" field="adescription" desc=""/>
+    <constraint exp="" field="link" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <editform tolerant="1"></editform>
@@ -154,10 +157,20 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField showLabel="1" name="datepublication" index="3"/>
-    <attributeEditorField showLabel="1" name="achannel" index="4"/>
-    <attributeEditorField showLabel="1" name="adescription" index="5"/>
-    <attributeEditorField showLabel="1" name="link" index="6"/>
+    <attributeEditorContainer name="Allgemein *" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorField name="datepublication" index="3" showLabel="1"/>
+      <attributeEditorField name="achannel" index="4" showLabel="1"/>
+      <attributeEditorField name="adescription" index="5" showLabel="1"/>
+      <attributeEditorField name="link" index="6" showLabel="1"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer name="Assets" visibilityExpression="" columnCount="1" visibilityExpressionEnabled="0" groupBox="0" showLabel="1">
+      <attributeEditorRelation name="assetitem_publication_publication_publication_T_Id" nmRelationId="" label="" relation="assetitem_publication_publication_publication_T_Id" relationWidgetTypeId="relation_editor" forceSuppressFormPopup="0" showLabel="0">
+        <editor_configuration type="Map">
+          <Option name="buttons" type="QString" value="NoButton"/>
+          <Option name="show_first_feature" type="bool" value="true"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
     <field name="T_Id" editable="1"/>
@@ -169,13 +182,13 @@ def my_form_open(dialog, layer, feature):
     <field name="link" editable="1"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="T_Id"/>
-    <field labelOnTop="0" name="T_Ili_Tid"/>
-    <field labelOnTop="0" name="T_basket"/>
-    <field labelOnTop="0" name="achannel"/>
-    <field labelOnTop="0" name="adescription"/>
-    <field labelOnTop="0" name="datepublication"/>
-    <field labelOnTop="0" name="link"/>
+    <field name="T_Id" labelOnTop="0"/>
+    <field name="T_Ili_Tid" labelOnTop="0"/>
+    <field name="T_basket" labelOnTop="0"/>
+    <field name="achannel" labelOnTop="0"/>
+    <field name="adescription" labelOnTop="0"/>
+    <field name="datepublication" labelOnTop="0"/>
+    <field name="link" labelOnTop="0"/>
   </labelOnTop>
   <reuseLastValue>
     <field reuseLastValue="0" name="T_Id"/>
@@ -190,7 +203,7 @@ def my_form_open(dialog, layer, feature):
   <widgets>
     <widget name="assetitem_publication_publication_publication_T_Id">
       <config type="Map">
-        <Option value="assetitem_publication_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="nm-rel"/>
+        <Option name="nm-rel" type="QString" value="assetitem_publication_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
       </config>
     </widget>
   </widgets>

--- a/lg_geolassets_v2/layerstyle/studyarea.qml
+++ b/lg_geolassets_v2/layerstyle/studyarea.qml
@@ -1,140 +1,140 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="LayerConfiguration|Symbology|Fields|Forms|CustomProperties" readOnly="0" version="3.25.0-Master">
+<qgis styleCategories="LayerConfiguration|Symbology|Fields|Forms|CustomProperties" readOnly="0" version="3.24.3-Tisler">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
     <Private>0</Private>
   </flags>
-  <renderer-v2 referencescale="-1" type="RuleRenderer" symbollevels="0" forceraster="0" enableorderby="0">
+  <renderer-v2 type="RuleRenderer" referencescale="-1" symbollevels="0" enableorderby="0" forceraster="0">
     <rules key="{0ebf4599-524f-499a-80dc-42a1f5c3945a}">
-      <rule filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" symbol="0" key="{991577ef-a980-4f06-a557-cdd37d48ef17}" label="Public"/>
-      <rule filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " symbol="1" key="{8110932f-f63c-437e-b09a-07d7f4cdd6cd}" label="Internal"/>
-      <rule filter="ELSE" symbol="2" key="{7bfb90d9-5c07-41b1-98d6-0570e71a18f5}" label="Not Available"/>
+      <rule label="Public" symbol="0" filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{991577ef-a980-4f06-a557-cdd37d48ef17}"/>
+      <rule label="Internal" symbol="1" filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " key="{8110932f-f63c-437e-b09a-07d7f4cdd6cd}"/>
+      <rule label="Not Available" symbol="2" filter="ELSE" key="{7bfb90d9-5c07-41b1-98d6-0570e71a18f5}"/>
     </rules>
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" force_rhr="0" is_animated="0" type="fill" name="0" frame_rate="10">
+      <symbol name="0" type="fill" clip_to_extent="1" force_rhr="0" alpha="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option name="name" type="QString" value=""/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
         </data_defined_properties>
-        <layer pass="0" class="SimpleFill" enabled="1" locked="0">
+        <layer class="SimpleFill" locked="0" pass="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="218,253,216,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="color" type="QString" value="218,253,216,191"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="offset" type="QString" value="0,0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="outline_color" type="QString" value="0,0,0,128"/>
+            <Option name="outline_style" type="QString" value="solid"/>
+            <Option name="outline_width" type="QString" value="0.6"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+            <Option name="style" type="QString" value="solid"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="218,253,216,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="218,253,216,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" force_rhr="0" is_animated="0" type="fill" name="1" frame_rate="10">
+      <symbol name="1" type="fill" clip_to_extent="1" force_rhr="0" alpha="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option name="name" type="QString" value=""/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
         </data_defined_properties>
-        <layer pass="0" class="SimpleFill" enabled="1" locked="0">
+        <layer class="SimpleFill" locked="0" pass="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="254,209,147,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="color" type="QString" value="254,209,147,191"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="offset" type="QString" value="0,0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="outline_color" type="QString" value="0,0,0,128"/>
+            <Option name="outline_style" type="QString" value="solid"/>
+            <Option name="outline_width" type="QString" value="0.6"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+            <Option name="style" type="QString" value="solid"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="254,209,147,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="254,209,147,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" force_rhr="0" is_animated="0" type="fill" name="2" frame_rate="10">
+      <symbol name="2" type="fill" clip_to_extent="1" force_rhr="0" alpha="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option name="name" type="QString" value=""/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
         </data_defined_properties>
-        <layer pass="0" class="SimpleFill" enabled="1" locked="0">
+        <layer class="SimpleFill" locked="0" pass="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="246,71,137,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="color" type="QString" value="246,71,137,191"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="offset" type="QString" value="0,0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="outline_color" type="QString" value="0,0,0,128"/>
+            <Option name="outline_style" type="QString" value="solid"/>
+            <Option name="outline_width" type="QString" value="0.6"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+            <Option name="style" type="QString" value="solid"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="246,71,137,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="246,71,137,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -143,159 +143,159 @@
   </renderer-v2>
   <customproperties>
     <Option type="Map">
-      <Option value="copy" type="QString" name="QFieldSync/action"/>
-      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
-      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
-      <Option type="List" name="dualview/previewExpressions">
-        <Option value="if(length(geom_to_wkt( $geometry ))>22,substr(geom_to_wkt( $geometry ),0,23)||'...',geom_to_wkt( $geometry ))" type="QString"/>
+      <Option name="QFieldSync/action" type="QString" value="copy"/>
+      <Option name="QFieldSync/cloud_action" type="QString" value="offline"/>
+      <Option name="QFieldSync/photo_naming" type="QString" value="{}"/>
+      <Option name="dualview/previewExpressions" type="List">
+        <Option type="QString" value="if(length(geom_to_wkt( $geometry ))>22,substr(geom_to_wkt( $geometry ),0,23)||'...',geom_to_wkt( $geometry ))"/>
       </Option>
-      <Option value="0" type="int" name="embeddedWidgets/count"/>
-      <Option type="StringList" name="variableNames">
-        <Option value="interlis_topic" type="QString"/>
+      <Option name="embeddedWidgets/count" type="int" value="0"/>
+      <Option name="variableNames" type="StringList">
+        <Option type="QString" value="interlis_topic"/>
       </Option>
-      <Option type="StringList" name="variableValues">
-        <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
+      <Option name="variableValues" type="StringList">
+        <Option type="QString" value="LG_GeolAssets_V2.GeolAssets"/>
       </Option>
     </Option>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id">
+    <field name="T_Id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_basket">
+    <field name="T_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="&quot;topic&quot; = 'LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" type="QString" name="ReferencedLayerId"/>
-            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studyarea_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="ChainFilters" type="bool" value="false"/>
+            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; = 'LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c"/>
+            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="studyarea_T_basket_T_ILI2DB_BASKET_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_Ili_Tid">
+    <field name="T_Ili_Tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="geomquality">
+    <field name="geomquality" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8" type="QString" name="ReferencedLayerId"/>
-            <Option value="GeomQualityItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studyarea_geomquality_geomqualityitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="ChainFilters" type="bool" value="false"/>
+            <Option name="FilterExpression" type="QString" value=""/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8"/>
+            <Option name="ReferencedLayerName" type="QString" value="GeomQualityItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="studyarea_geomquality_geomqualityitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="assetitem_assetitem">
+    <field name="assetitem_assetitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="true" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e" type="QString" name="ReferencedLayerId"/>
-            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studyarea_assetitem_assetitem_assetitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="true"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="studyarea_assetitem_assetitem_assetitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="assetitem_lg_geolssts_v2geolassets_assetitem">
+    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_4/lg_geolAssets_v2_data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="AssetItem_655d7d08_f608_4aef_b23f_9bfc2ff514b1" type="QString" name="ReferencedLayerId"/>
-            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studyarea_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="studyarea_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="T_Id" index="0" name=""/>
-    <alias field="T_basket" index="1" name=""/>
-    <alias field="T_Ili_Tid" index="2" name=""/>
-    <alias field="geomquality" index="3" name="Qualität"/>
-    <alias field="assetitem_assetitem" index="4" name="AssetItem"/>
-    <alias field="assetitem_lg_geolssts_v2geolassets_assetitem" index="5" name="AssetItem"/>
+    <alias name="" index="0" field="T_Id"/>
+    <alias name="" index="1" field="T_basket"/>
+    <alias name="" index="2" field="T_Ili_Tid"/>
+    <alias name="Qualität" index="3" field="geomquality"/>
+    <alias name="AssetItem" index="4" field="assetitem_assetitem"/>
+    <alias name="AssetItem" index="5" field="assetitem_lg_geolssts_v2geolassets_assetitem"/>
   </aliases>
   <defaults>
-    <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
-    <default field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets" applyOnUpdate="0"/>
-    <default field="T_Ili_Tid" expression="substr(uuid(), 2, 36)" applyOnUpdate="0"/>
-    <default field="geomquality" expression="" applyOnUpdate="0"/>
-    <default field="assetitem_assetitem" expression="" applyOnUpdate="0"/>
-    <default field="assetitem_lg_geolssts_v2geolassets_assetitem" expression="" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
+    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
+    <default applyOnUpdate="0" field="T_Ili_Tid" expression="substr(uuid(), 2, 36)"/>
+    <default applyOnUpdate="0" field="geomquality" expression=""/>
+    <default applyOnUpdate="0" field="assetitem_assetitem" expression=""/>
+    <default applyOnUpdate="0" field="assetitem_lg_geolssts_v2geolassets_assetitem" expression=""/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" notnull_strength="1" field="T_Id" exp_strength="0" constraints="3"/>
-    <constraint unique_strength="0" notnull_strength="1" field="T_basket" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="T_Ili_Tid" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="geomquality" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="assetitem_assetitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="1" field="assetitem_lg_geolssts_v2geolassets_assetitem" exp_strength="0" constraints="1"/>
+    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="1" constraints="2" field="T_Ili_Tid" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="geomquality" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="assetitem_assetitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="assetitem_lg_geolssts_v2geolassets_assetitem" notnull_strength="1" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="T_Id" desc="" exp=""/>
-    <constraint field="T_basket" desc="" exp=""/>
-    <constraint field="T_Ili_Tid" desc="" exp=""/>
-    <constraint field="geomquality" desc="" exp=""/>
-    <constraint field="assetitem_assetitem" desc="" exp=""/>
-    <constraint field="assetitem_lg_geolssts_v2geolassets_assetitem" desc="" exp=""/>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="T_Ili_Tid" desc=""/>
+    <constraint exp="" field="geomquality" desc=""/>
+    <constraint exp="" field="assetitem_assetitem" desc=""/>
+    <constraint exp="" field="assetitem_lg_geolssts_v2geolassets_assetitem" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <editform tolerant="1"></editform>
@@ -320,8 +320,8 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField showLabel="1" name="geomquality" index="3"/>
-    <attributeEditorField showLabel="1" name="assetitem_lg_geolssts_v2geolassets_assetitem" index="5"/>
+    <attributeEditorField name="geomquality" index="3" showLabel="1"/>
+    <attributeEditorField name="assetitem_lg_geolssts_v2geolassets_assetitem" index="5" showLabel="1"/>
   </attributeEditorForm>
   <editable>
     <field name="T_Id" editable="1"/>
@@ -332,12 +332,12 @@ def my_form_open(dialog, layer, feature):
     <field name="geomquality" editable="1"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="T_Id"/>
-    <field labelOnTop="0" name="T_Ili_Tid"/>
-    <field labelOnTop="0" name="T_basket"/>
-    <field labelOnTop="0" name="assetitem_assetitem"/>
-    <field labelOnTop="0" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
-    <field labelOnTop="0" name="geomquality"/>
+    <field name="T_Id" labelOnTop="0"/>
+    <field name="T_Ili_Tid" labelOnTop="0"/>
+    <field name="T_basket" labelOnTop="0"/>
+    <field name="assetitem_assetitem" labelOnTop="0"/>
+    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" labelOnTop="0"/>
+    <field name="geomquality" labelOnTop="0"/>
   </labelOnTop>
   <reuseLastValue>
     <field reuseLastValue="0" name="T_Id"/>

--- a/lg_geolassets_v2/layerstyle/studyarea.qml
+++ b/lg_geolassets_v2/layerstyle/studyarea.qml
@@ -1,140 +1,666 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="LayerConfiguration|Symbology|Fields|Forms|CustomProperties" readOnly="0" version="3.24.3-Tisler">
+<qgis readOnly="0" version="3.22.11-Białowieża" styleCategories="LayerConfiguration|Symbology|Fields|Forms|CustomProperties">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
     <Private>0</Private>
   </flags>
-  <renderer-v2 type="RuleRenderer" referencescale="-1" symbollevels="0" enableorderby="0" forceraster="0">
-    <rules key="{0ebf4599-524f-499a-80dc-42a1f5c3945a}">
-      <rule label="Public" symbol="0" filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{991577ef-a980-4f06-a557-cdd37d48ef17}"/>
-      <rule label="Internal" symbol="1" filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " key="{8110932f-f63c-437e-b09a-07d7f4cdd6cd}"/>
-      <rule label="Not Available" symbol="2" filter="ELSE" key="{7bfb90d9-5c07-41b1-98d6-0570e71a18f5}"/>
+  <renderer-v2 forceraster="0" type="RuleRenderer" enableorderby="0" referencescale="-1" symbollevels="0">
+    <rules key="{b6237354-ee64-41ad-a209-711a77061aec}">
+      <rule checkstate="0" filter="with_variable( 'width', bounds_width($geometry), with_variable( 'height', bounds_height($geometry), &#xa;1010 > @width AND&#xa;@width > 990 AND &#xa;1010 > @height AND &#xa;@height > 990&#xa;))" label="1x1" key="{3d9d7f8e-6887-4b63-9396-9eeb43b336dc}">
+        <rule filter="ELSE" symbol="0" label="Not Available" key="{5f29e85c-46b0-480c-a980-b8d9e7c41ae9}"/>
+        <rule filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " symbol="1" label="Internal" key="{f26542f7-ad82-4e31-bf4b-9510692c2640}"/>
+        <rule filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" symbol="2" label="Public" key="{4f412996-4ebd-467c-9a0b-bff20b4df48d}"/>
+      </rule>
+      <rule checkstate="0" filter="with_variable( 'width', bounds_width($geometry), with_variable( 'height', bounds_height($geometry), &#xa;10100 > @width AND&#xa;@width > 9900 AND &#xa;10100 > @height AND &#xa;@height > 9900&#xa;))" label="10x10" key="{2ad4547c-0db0-4f01-92b1-4da7813bf846}">
+        <rule filter="ELSE" symbol="3" label="Not Available" key="{3cc909ec-ec2c-4410-85fe-1790de0d8ad1}"/>
+        <rule filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " symbol="4" label="Internal" key="{2da4c19a-da6f-454f-9e08-af50b7c6f0a6}"/>
+        <rule filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" symbol="5" label="Public" key="{d26ff565-a481-4c73-9bad-b7de00272931}"/>
+      </rule>
+      <rule filter="$area &lt; 100000000 AND NOT&#xa;with_variable( 'width', bounds_width($geometry), with_variable( 'height', bounds_height($geometry), &#xa;1010 > @width AND&#xa;@width > 990 AND &#xa;1010 > @height AND &#xa;@height > 990&#xa;)) AND NOT&#xa;with_variable( 'width', bounds_width($geometry), with_variable( 'height', bounds_height($geometry), &#xa;10100 > @width AND&#xa;@width > 9900 AND &#xa;10100 > @height AND &#xa;@height > 9900&#xa;))" label="0 - 100" key="{a6982310-21ed-4397-8a6c-de819f225681}">
+        <rule filter="ELSE" symbol="6" label="Not Available" key="{53ba27f4-9995-4e2b-b270-27012a4fa4cd}"/>
+        <rule filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " symbol="7" label="Internal" key="{91340e1f-ee5d-483a-98ad-28aecb60be6e}"/>
+        <rule filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" symbol="8" label="Public" key="{cc322a90-1933-47bf-b625-b18e1e353ec4}"/>
+      </rule>
+      <rule checkstate="0" filter="100000000 &lt; $area AND $area &lt; 21000000000" label="100 - 21'000" key="{0025989f-3915-40dd-92e5-bba4301aeb32}">
+        <rule filter="ELSE" symbol="9" label="Not Available" key="{cb7f5f87-d4ad-44bd-920c-3a27913fe629}"/>
+        <rule filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " symbol="10" label="Internal" key="{a54897b2-fd02-42c2-8fec-465dd5ef29a1}"/>
+        <rule filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" symbol="11" label="Public" key="{973d703a-db45-4a9a-bc0b-e17661c1b9ef}"/>
+      </rule>
+      <rule checkstate="0" filter="$area > 21000000000" label="gt. 21'000" key="{0d8082b0-fb72-4beb-a454-d0dcf9605d9f}">
+        <rule filter="ELSE" symbol="12" label="Not Available" key="{1f62ffc0-5d11-40ad-8042-ff11a86cc4c8}"/>
+        <rule filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " symbol="13" label="Internal" key="{171f9819-a8cd-40f7-baea-61785a71eefd}"/>
+        <rule filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" symbol="14" label="Public" key="{d6f4ed15-9537-43bd-afd3-379481ff01c8}"/>
+      </rule>
     </rules>
     <symbols>
-      <symbol name="0" type="fill" clip_to_extent="1" force_rhr="0" alpha="1">
+      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" locked="0" pass="0" enabled="1">
+        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="color" type="QString" value="218,253,216,191"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="offset" type="QString" value="0,0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="outline_color" type="QString" value="0,0,0,128"/>
-            <Option name="outline_style" type="QString" value="solid"/>
-            <Option name="outline_width" type="QString" value="0.6"/>
-            <Option name="outline_width_unit" type="QString" value="MM"/>
-            <Option name="style" type="QString" value="solid"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="246,71,137,191" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,128" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.6" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
           </Option>
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="218,253,216,191"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="0,0,0,128"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.6"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="solid"/>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="246,71,137,191" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,128" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.6" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="1" type="fill" clip_to_extent="1" force_rhr="0" alpha="1">
+      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" locked="0" pass="0" enabled="1">
+        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="color" type="QString" value="254,209,147,191"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="offset" type="QString" value="0,0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="outline_color" type="QString" value="0,0,0,128"/>
-            <Option name="outline_style" type="QString" value="solid"/>
-            <Option name="outline_width" type="QString" value="0.6"/>
-            <Option name="outline_width_unit" type="QString" value="MM"/>
-            <Option name="style" type="QString" value="solid"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="254,209,147,191" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,128" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.6" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
           </Option>
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="254,209,147,191"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="0,0,0,128"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.6"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="solid"/>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="254,209,147,191" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,128" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.6" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" type="fill" clip_to_extent="1" force_rhr="0" alpha="1">
+      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="10">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleFill" locked="0" pass="0" enabled="1">
+        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
           <Option type="Map">
-            <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="color" type="QString" value="246,71,137,191"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="offset" type="QString" value="0,0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="outline_color" type="QString" value="0,0,0,128"/>
-            <Option name="outline_style" type="QString" value="solid"/>
-            <Option name="outline_width" type="QString" value="0.6"/>
-            <Option name="outline_width_unit" type="QString" value="MM"/>
-            <Option name="style" type="QString" value="solid"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="254,209,147,191" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,128" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.6" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
           </Option>
-          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="color" v="246,71,137,191"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="0,0,0,128"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0.6"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="style" v="solid"/>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="254,209,147,191" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,128" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.6" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="11">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="218,253,216,191" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,128" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.6" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="218,253,216,191" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,128" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.6" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="12">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="246,71,137,191" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,128" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.6" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="246,71,137,191" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,128" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.6" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="13">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="254,209,147,191" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,128" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.6" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="254,209,147,191" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,128" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.6" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="14">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="218,253,216,191" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,128" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.6" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="218,253,216,191" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,128" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.6" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="2">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="218,253,216,191" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,128" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.6" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="218,253,216,191" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,128" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.6" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="3">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="246,71,137,191" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,128" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.6" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="246,71,137,191" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,128" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.6" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="4">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="254,209,147,191" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,128" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.6" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="254,209,147,191" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,128" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.6" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="5">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="218,253,216,191" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,128" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.6" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="218,253,216,191" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,128" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.6" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="6">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="246,71,137,191" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,128" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.6" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="246,71,137,191" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,128" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.6" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="7">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="254,209,147,191" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,128" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.6" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="254,209,147,191" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,128" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.6" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="8">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="218,253,216,191" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,128" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.6" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="218,253,216,191" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,128" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.6" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="9">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option name="properties"/>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+            <Option value="246,71,137,191" type="QString" name="color"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,128" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0.6" type="QString" name="outline_width"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="solid" type="QString" name="style"/>
+          </Option>
+          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+          <prop v="246,71,137,191" k="color"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,128" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0.6" k="outline_width"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="solid" k="style"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -143,151 +669,151 @@
   </renderer-v2>
   <customproperties>
     <Option type="Map">
-      <Option name="QFieldSync/action" type="QString" value="copy"/>
-      <Option name="QFieldSync/cloud_action" type="QString" value="offline"/>
-      <Option name="QFieldSync/photo_naming" type="QString" value="{}"/>
-      <Option name="dualview/previewExpressions" type="List">
-        <Option type="QString" value="if(length(geom_to_wkt( $geometry ))>22,substr(geom_to_wkt( $geometry ),0,23)||'...',geom_to_wkt( $geometry ))"/>
+      <Option value="copy" type="QString" name="QFieldSync/action"/>
+      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
+      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
+      <Option type="List" name="dualview/previewExpressions">
+        <Option value="if(length(geom_to_wkt( $geometry ))>22,substr(geom_to_wkt( $geometry ),0,23)||'...',geom_to_wkt( $geometry ))" type="QString"/>
       </Option>
-      <Option name="embeddedWidgets/count" type="int" value="0"/>
-      <Option name="variableNames" type="StringList">
-        <Option type="QString" value="interlis_topic"/>
+      <Option value="0" type="int" name="embeddedWidgets/count"/>
+      <Option type="StringList" name="variableNames">
+        <Option value="interlis_topic" type="QString"/>
       </Option>
-      <Option name="variableValues" type="StringList">
-        <Option type="QString" value="LG_GeolAssets_V2.GeolAssets"/>
+      <Option type="StringList" name="variableValues">
+        <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
       </Option>
     </Option>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <fieldConfiguration>
-    <field name="T_Id" configurationFlags="None">
+    <field configurationFlags="None" name="T_Id">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="T_basket" configurationFlags="None">
+    <field configurationFlags="None" name="T_basket">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="true"/>
-            <Option name="ChainFilters" type="bool" value="false"/>
-            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; = 'LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
-            <Option name="FilterFields" type="invalid"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="true"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c"/>
-            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="studyarea_T_basket_T_ILI2DB_BASKET_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="false"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="true" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="ChainFilters"/>
+            <Option value="&quot;topic&quot; = 'LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString" name="FilterExpression"/>
+            <Option type="invalid" name="FilterFields"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="true" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" type="QString" name="ReferencedLayerId"/>
+            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="studyarea_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="false" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="T_Ili_Tid" configurationFlags="None">
+    <field configurationFlags="None" name="T_Ili_Tid">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="geomquality" configurationFlags="None">
+    <field configurationFlags="None" name="geomquality">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="true"/>
-            <Option name="ChainFilters" type="bool" value="false"/>
-            <Option name="FilterExpression" type="QString" value=""/>
-            <Option name="FilterFields" type="invalid"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="true"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8"/>
-            <Option name="ReferencedLayerName" type="QString" value="GeomQualityItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="studyarea_geomquality_geomqualityitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="false"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="true" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="ChainFilters"/>
+            <Option value="" type="QString" name="FilterExpression"/>
+            <Option type="invalid" name="FilterFields"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="true" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8" type="QString" name="ReferencedLayerId"/>
+            <Option value="GeomQualityItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="studyarea_geomquality_geomqualityitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="false" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="assetitem_assetitem" configurationFlags="None">
+    <field configurationFlags="None" name="assetitem_assetitem">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="true"/>
-            <Option name="AllowNULL" type="bool" value="true"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="true"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e"/>
-            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="studyarea_assetitem_assetitem_assetitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="false"/>
+            <Option value="true" type="bool" name="AllowAddFeatures"/>
+            <Option value="true" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="true" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e" type="QString" name="ReferencedLayerId"/>
+            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="studyarea_assetitem_assetitem_assetitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="false" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" configurationFlags="None">
+    <field configurationFlags="None" name="assetitem_lg_geolssts_v2geolassets_assetitem">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="true"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="true"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
-            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="studyarea_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="true" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="true" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d" type="QString" name="ReferencedLayerId"/>
+            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="studyarea_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="T_Id"/>
-    <alias name="" index="1" field="T_basket"/>
-    <alias name="" index="2" field="T_Ili_Tid"/>
-    <alias name="Qualität" index="3" field="geomquality"/>
-    <alias name="AssetItem" index="4" field="assetitem_assetitem"/>
-    <alias name="AssetItem" index="5" field="assetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <alias field="T_Id" index="0" name=""/>
+    <alias field="T_basket" index="1" name=""/>
+    <alias field="T_Ili_Tid" index="2" name=""/>
+    <alias field="geomquality" index="3" name="Qualität"/>
+    <alias field="assetitem_assetitem" index="4" name="AssetItem"/>
+    <alias field="assetitem_lg_geolssts_v2geolassets_assetitem" index="5" name="AssetItem"/>
   </aliases>
   <defaults>
-    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
-    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
-    <default applyOnUpdate="0" field="T_Ili_Tid" expression="substr(uuid(), 2, 36)"/>
-    <default applyOnUpdate="0" field="geomquality" expression=""/>
-    <default applyOnUpdate="0" field="assetitem_assetitem" expression=""/>
-    <default applyOnUpdate="0" field="assetitem_lg_geolssts_v2geolassets_assetitem" expression=""/>
+    <default expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" field="T_Id" applyOnUpdate="0"/>
+    <default expression="@default_basket_lg_geolassets_v2_geolassets" field="T_basket" applyOnUpdate="0"/>
+    <default expression="substr(uuid(), 2, 36)" field="T_Ili_Tid" applyOnUpdate="0"/>
+    <default expression="" field="geomquality" applyOnUpdate="0"/>
+    <default expression="" field="assetitem_assetitem" applyOnUpdate="0"/>
+    <default expression="" field="assetitem_lg_geolssts_v2geolassets_assetitem" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="1" constraints="2" field="T_Ili_Tid" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="geomquality" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="assetitem_assetitem" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" field="assetitem_lg_geolssts_v2geolassets_assetitem" notnull_strength="1" exp_strength="0"/>
+    <constraint field="T_Id" exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3"/>
+    <constraint field="T_basket" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint field="T_Ili_Tid" exp_strength="0" unique_strength="1" notnull_strength="0" constraints="2"/>
+    <constraint field="geomquality" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="assetitem_assetitem" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="assetitem_lg_geolssts_v2geolassets_assetitem" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="T_Id" desc=""/>
@@ -320,24 +846,24 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField name="geomquality" index="3" showLabel="1"/>
-    <attributeEditorField name="assetitem_lg_geolssts_v2geolassets_assetitem" index="5" showLabel="1"/>
+    <attributeEditorField index="3" showLabel="1" name="geomquality"/>
+    <attributeEditorField index="5" showLabel="1" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
   </attributeEditorForm>
   <editable>
-    <field name="T_Id" editable="1"/>
-    <field name="T_Ili_Tid" editable="1"/>
-    <field name="T_basket" editable="1"/>
-    <field name="assetitem_assetitem" editable="1"/>
-    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" editable="0"/>
-    <field name="geomquality" editable="1"/>
+    <field editable="1" name="T_Id"/>
+    <field editable="1" name="T_Ili_Tid"/>
+    <field editable="1" name="T_basket"/>
+    <field editable="1" name="assetitem_assetitem"/>
+    <field editable="0" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <field editable="1" name="geomquality"/>
   </editable>
   <labelOnTop>
-    <field name="T_Id" labelOnTop="0"/>
-    <field name="T_Ili_Tid" labelOnTop="0"/>
-    <field name="T_basket" labelOnTop="0"/>
-    <field name="assetitem_assetitem" labelOnTop="0"/>
-    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" labelOnTop="0"/>
-    <field name="geomquality" labelOnTop="0"/>
+    <field labelOnTop="0" name="T_Id"/>
+    <field labelOnTop="0" name="T_Ili_Tid"/>
+    <field labelOnTop="0" name="T_basket"/>
+    <field labelOnTop="0" name="assetitem_assetitem"/>
+    <field labelOnTop="0" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <field labelOnTop="0" name="geomquality"/>
   </labelOnTop>
   <reuseLastValue>
     <field reuseLastValue="0" name="T_Id"/>

--- a/lg_geolassets_v2/layerstyle/studyarea.qml
+++ b/lg_geolassets_v2/layerstyle/studyarea.qml
@@ -6,661 +6,792 @@
     <Searchable>1</Searchable>
     <Private>0</Private>
   </flags>
-  <renderer-v2 forceraster="0" type="RuleRenderer" enableorderby="0" referencescale="-1" symbollevels="0">
+  <renderer-v2 enableorderby="0" referencescale="-1" symbollevels="0" forceraster="0" type="RuleRenderer">
     <rules key="{b6237354-ee64-41ad-a209-711a77061aec}">
-      <rule checkstate="0" filter="with_variable( 'width', bounds_width($geometry), with_variable( 'height', bounds_height($geometry), &#xa;1010 > @width AND&#xa;@width > 990 AND &#xa;1010 > @height AND &#xa;@height > 990&#xa;))" label="1x1" key="{3d9d7f8e-6887-4b63-9396-9eeb43b336dc}">
-        <rule filter="ELSE" symbol="0" label="Not Available" key="{5f29e85c-46b0-480c-a980-b8d9e7c41ae9}"/>
-        <rule filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " symbol="1" label="Internal" key="{f26542f7-ad82-4e31-bf4b-9510692c2640}"/>
-        <rule filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" symbol="2" label="Public" key="{4f412996-4ebd-467c-9a0b-bff20b4df48d}"/>
+      <rule filter="with_variable( 'width', bounds_width($geometry), with_variable( 'height', bounds_height($geometry), &#xa;1010 > @width AND&#xa;@width > 990 AND &#xa;1010 > @height AND &#xa;@height > 990&#xa;))" checkstate="0" key="{3d9d7f8e-6887-4b63-9396-9eeb43b336dc}" label="1x1">
+        <rule symbol="0" filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{4f412996-4ebd-467c-9a0b-bff20b4df48d}" label="Public"/>
+        <rule symbol="1" filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') &#xa;AND NOT attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{3382c80c-e5ad-4286-a90c-e8c237404f53}" label="Internal"/>
+        <rule symbol="2" filter="ELSE" key="{94329923-fee1-4744-980b-631f2ea34007}" label="Not Available"/>
       </rule>
-      <rule checkstate="0" filter="with_variable( 'width', bounds_width($geometry), with_variable( 'height', bounds_height($geometry), &#xa;10100 > @width AND&#xa;@width > 9900 AND &#xa;10100 > @height AND &#xa;@height > 9900&#xa;))" label="10x10" key="{2ad4547c-0db0-4f01-92b1-4da7813bf846}">
-        <rule filter="ELSE" symbol="3" label="Not Available" key="{3cc909ec-ec2c-4410-85fe-1790de0d8ad1}"/>
-        <rule filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " symbol="4" label="Internal" key="{2da4c19a-da6f-454f-9e08-af50b7c6f0a6}"/>
-        <rule filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" symbol="5" label="Public" key="{d26ff565-a481-4c73-9bad-b7de00272931}"/>
+      <rule filter="with_variable( 'width', bounds_width($geometry), with_variable( 'height', bounds_height($geometry), &#xa;10100 > @width AND&#xa;@width > 9900 AND &#xa;10100 > @height AND &#xa;@height > 9900&#xa;))" checkstate="0" key="{2ad4547c-0db0-4f01-92b1-4da7813bf846}" label="10x10">
+        <rule symbol="3" filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{d26ff565-a481-4c73-9bad-b7de00272931}" label="Public"/>
+        <rule symbol="4" filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') &#xa;AND NOT attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{58e551e4-d042-4a7b-9f2f-2f3511a3dcac}" label="Internal"/>
+        <rule symbol="5" filter="ELSE" key="{ef3d901d-d816-4f1d-9cc7-2ac6aa0da0a1}" label="Not Available"/>
       </rule>
-      <rule filter="$area &lt; 100000000 AND NOT&#xa;with_variable( 'width', bounds_width($geometry), with_variable( 'height', bounds_height($geometry), &#xa;1010 > @width AND&#xa;@width > 990 AND &#xa;1010 > @height AND &#xa;@height > 990&#xa;)) AND NOT&#xa;with_variable( 'width', bounds_width($geometry), with_variable( 'height', bounds_height($geometry), &#xa;10100 > @width AND&#xa;@width > 9900 AND &#xa;10100 > @height AND &#xa;@height > 9900&#xa;))" label="0 - 100" key="{a6982310-21ed-4397-8a6c-de819f225681}">
-        <rule filter="ELSE" symbol="6" label="Not Available" key="{53ba27f4-9995-4e2b-b270-27012a4fa4cd}"/>
-        <rule filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " symbol="7" label="Internal" key="{91340e1f-ee5d-483a-98ad-28aecb60be6e}"/>
-        <rule filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" symbol="8" label="Public" key="{cc322a90-1933-47bf-b625-b18e1e353ec4}"/>
+      <rule filter="$area &lt; 100000000 AND NOT&#xa;with_variable( 'width', bounds_width($geometry), with_variable( 'height', bounds_height($geometry), &#xa;1010 > @width AND&#xa;@width > 990 AND &#xa;1010 > @height AND &#xa;@height > 990&#xa;)) AND NOT&#xa;with_variable( 'width', bounds_width($geometry), with_variable( 'height', bounds_height($geometry), &#xa;10100 > @width AND&#xa;@width > 9900 AND &#xa;10100 > @height AND &#xa;@height > 9900&#xa;))" checkstate="0" key="{a6982310-21ed-4397-8a6c-de819f225681}" label="0 - 100">
+        <rule symbol="6" filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{cc322a90-1933-47bf-b625-b18e1e353ec4}" label="Public"/>
+        <rule symbol="7" filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') &#xa;AND NOT&#xa;attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{a0cf73bf-3c2e-4525-a139-825b7e91f6ce}" label="Internal"/>
+        <rule symbol="8" filter="ELSE" key="{da0af733-6c67-43dc-8473-bd3062b2c10a}" label="Not Available"/>
       </rule>
-      <rule checkstate="0" filter="100000000 &lt; $area AND $area &lt; 21000000000" label="100 - 21'000" key="{0025989f-3915-40dd-92e5-bba4301aeb32}">
-        <rule filter="ELSE" symbol="9" label="Not Available" key="{cb7f5f87-d4ad-44bd-920c-3a27913fe629}"/>
-        <rule filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " symbol="10" label="Internal" key="{a54897b2-fd02-42c2-8fec-465dd5ef29a1}"/>
-        <rule filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" symbol="11" label="Public" key="{973d703a-db45-4a9a-bc0b-e17661c1b9ef}"/>
+      <rule filter="100000000 &lt; $area AND $area &lt; 1000000000" key="{0025989f-3915-40dd-92e5-bba4301aeb32}" label="100 - 1'000">
+        <rule symbol="9" filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{973d703a-db45-4a9a-bc0b-e17661c1b9ef}" label="Public"/>
+        <rule symbol="10" filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') &#xa;AND NOT&#xa;attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{b9eb6452-5211-4f9d-b815-ba761e6e78cc}" label="Internal"/>
+        <rule symbol="11" filter="ELSE" key="{47c2750e-5283-4113-a1e7-d008e5b88f21}" label="Not Available"/>
       </rule>
-      <rule checkstate="0" filter="$area > 21000000000" label="gt. 21'000" key="{0d8082b0-fb72-4beb-a454-d0dcf9605d9f}">
-        <rule filter="ELSE" symbol="12" label="Not Available" key="{1f62ffc0-5d11-40ad-8042-ff11a86cc4c8}"/>
-        <rule filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " symbol="13" label="Internal" key="{171f9819-a8cd-40f7-baea-61785a71eefd}"/>
-        <rule filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" symbol="14" label="Public" key="{d6f4ed15-9537-43bd-afd3-379481ff01c8}"/>
+      <rule filter="1000000000 &lt; $area AND $area &lt; 21000000000" checkstate="0" key="{cf098f4b-5f0d-4e29-8b8f-1ea86d5bd58a}" label="1'000 - 21'000">
+        <rule symbol="12" filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{4429e15b-bb02-4d3a-87f1-a2122921d621}" label="Public"/>
+        <rule symbol="13" filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') &#xa;AND NOT&#xa;attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{35880ae0-e3a8-435b-937c-7c38f7c31074}" label="Internal"/>
+        <rule symbol="14" filter="ELSE" key="{cd7d1f8d-705d-469d-876b-1b8d59e38815}" label="Not Available"/>
+      </rule>
+      <rule filter="$area > 21000000000" checkstate="0" key="{0d8082b0-fb72-4beb-a454-d0dcf9605d9f}" label="gt. 21'000">
+        <rule symbol="15" filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{d6f4ed15-9537-43bd-afd3-379481ff01c8}" label="Public"/>
+        <rule symbol="16" filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') &#xa;AND NOT&#xa;attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{09b5b81b-b52f-4659-ab8f-807744de668c}" label="Internal"/>
+        <rule symbol="17" filter="ELSE" key="{e1ac489f-57ae-43f4-9694-62b7a91b277a}" label="Not Available"/>
       </rule>
     </rules>
     <symbols>
-      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="0">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="0" type="fill">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="246,71,137,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="218,253,216,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="246,71,137,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="218,253,216,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="1">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="1" type="fill">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="254,209,147,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="254,209,147,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="254,209,147,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="254,209,147,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="10">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="10" type="fill">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="254,209,147,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="254,209,147,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="254,209,147,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="254,209,147,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="11">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="11" type="fill">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="218,253,216,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="246,71,137,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="218,253,216,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="246,71,137,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="12">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="12" type="fill">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="246,71,137,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="218,253,216,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="246,71,137,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="218,253,216,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="13">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="13" type="fill">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="254,209,147,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="254,209,147,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="254,209,147,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="254,209,147,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="14">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="14" type="fill">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="218,253,216,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="246,71,137,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="218,253,216,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="246,71,137,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="2">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="15" type="fill">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="218,253,216,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="218,253,216,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="218,253,216,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="218,253,216,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="3">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="16" type="fill">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="246,71,137,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="254,209,147,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="246,71,137,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="254,209,147,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="4">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="17" type="fill">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="254,209,147,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="246,71,137,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="254,209,147,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="246,71,137,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="5">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="2" type="fill">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="218,253,216,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="246,71,137,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="218,253,216,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="246,71,137,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="6">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="3" type="fill">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="246,71,137,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="218,253,216,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="246,71,137,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="218,253,216,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="7">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="4" type="fill">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="254,209,147,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="254,209,147,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="254,209,147,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="254,209,147,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="8">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="5" type="fill">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="218,253,216,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="246,71,137,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="218,253,216,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="246,71,137,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="fill" clip_to_extent="1" name="9">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="6" type="fill">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
-            <Option value="246,71,137,191" type="QString" name="color"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,128" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0.6" type="QString" name="outline_width"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="solid" type="QString" name="style"/>
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="218,253,216,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
           </Option>
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="246,71,137,191" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,128" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0.6" k="outline_width"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="218,253,216,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="7" type="fill">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" name="name" type="QString"/>
+            <Option name="properties"/>
+            <Option value="collection" name="type" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="254,209,147,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
+          </Option>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="254,209,147,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" name="name" type="QString"/>
+              <Option name="properties"/>
+              <Option value="collection" name="type" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="8" type="fill">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" name="name" type="QString"/>
+            <Option name="properties"/>
+            <Option value="collection" name="type" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="246,71,137,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
+          </Option>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="246,71,137,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" name="name" type="QString"/>
+              <Option name="properties"/>
+              <Option value="collection" name="type" type="QString"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="9" type="fill">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option value="" name="name" type="QString"/>
+            <Option name="properties"/>
+            <Option value="collection" name="type" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <layer pass="0" class="SimpleFill" locked="0" enabled="1">
+          <Option type="Map">
+            <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+            <Option value="218,253,216,191" name="color" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,128" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0.6" name="outline_width" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="solid" name="style" type="QString"/>
+          </Option>
+          <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="color" v="218,253,216,191"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,128"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" name="name" type="QString"/>
+              <Option name="properties"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -669,17 +800,17 @@
   </renderer-v2>
   <customproperties>
     <Option type="Map">
-      <Option value="copy" type="QString" name="QFieldSync/action"/>
-      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
-      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
-      <Option type="List" name="dualview/previewExpressions">
+      <Option value="copy" name="QFieldSync/action" type="QString"/>
+      <Option value="offline" name="QFieldSync/cloud_action" type="QString"/>
+      <Option value="{}" name="QFieldSync/photo_naming" type="QString"/>
+      <Option name="dualview/previewExpressions" type="List">
         <Option value="if(length(geom_to_wkt( $geometry ))>22,substr(geom_to_wkt( $geometry ),0,23)||'...',geom_to_wkt( $geometry ))" type="QString"/>
       </Option>
-      <Option value="0" type="int" name="embeddedWidgets/count"/>
-      <Option type="StringList" name="variableNames">
+      <Option value="0" name="embeddedWidgets/count" type="int"/>
+      <Option name="variableNames" type="StringList">
         <Option value="interlis_topic" type="QString"/>
       </Option>
-      <Option type="StringList" name="variableValues">
+      <Option name="variableValues" type="StringList">
         <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
       </Option>
     </Option>
@@ -687,105 +818,105 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id">
+    <field name="T_Id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_basket">
+    <field name="T_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="&quot;topic&quot; = 'LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" type="QString" name="ReferencedLayerId"/>
-            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studyarea_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option value="false" name="AllowAddFeatures" type="bool"/>
+            <Option value="true" name="AllowNULL" type="bool"/>
+            <Option value="false" name="ChainFilters" type="bool"/>
+            <Option value="&quot;topic&quot; = 'LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" name="FilterExpression" type="QString"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option value="false" name="MapIdentification" type="bool"/>
+            <Option value="true" name="OrderByValue" type="bool"/>
+            <Option value="false" name="ReadOnly" type="bool"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" name="ReferencedLayerDataSource" type="QString"/>
+            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" name="ReferencedLayerId" type="QString"/>
+            <Option value="T_ILI2DB_BASKET" name="ReferencedLayerName" type="QString"/>
+            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
+            <Option value="studyarea_T_basket_T_ILI2DB_BASKET_T_Id" name="Relation" type="QString"/>
+            <Option value="false" name="ShowForm" type="bool"/>
+            <Option value="false" name="ShowOpenFormButton" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_Ili_Tid">
+    <field name="T_Ili_Tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="geomquality">
+    <field name="geomquality" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8" type="QString" name="ReferencedLayerId"/>
-            <Option value="GeomQualityItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studyarea_geomquality_geomqualityitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option value="false" name="AllowAddFeatures" type="bool"/>
+            <Option value="true" name="AllowNULL" type="bool"/>
+            <Option value="false" name="ChainFilters" type="bool"/>
+            <Option value="" name="FilterExpression" type="QString"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option value="false" name="MapIdentification" type="bool"/>
+            <Option value="true" name="OrderByValue" type="bool"/>
+            <Option value="false" name="ReadOnly" type="bool"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem" name="ReferencedLayerDataSource" type="QString"/>
+            <Option value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8" name="ReferencedLayerId" type="QString"/>
+            <Option value="GeomQualityItem" name="ReferencedLayerName" type="QString"/>
+            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
+            <Option value="studyarea_geomquality_geomqualityitem_T_Id" name="Relation" type="QString"/>
+            <Option value="false" name="ShowForm" type="bool"/>
+            <Option value="false" name="ShowOpenFormButton" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="assetitem_assetitem">
+    <field name="assetitem_assetitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="true" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e" type="QString" name="ReferencedLayerId"/>
-            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studyarea_assetitem_assetitem_assetitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option value="true" name="AllowAddFeatures" type="bool"/>
+            <Option value="true" name="AllowNULL" type="bool"/>
+            <Option value="false" name="MapIdentification" type="bool"/>
+            <Option value="true" name="OrderByValue" type="bool"/>
+            <Option value="false" name="ReadOnly" type="bool"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem" name="ReferencedLayerDataSource" type="QString"/>
+            <Option value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e" name="ReferencedLayerId" type="QString"/>
+            <Option value="AssetItem" name="ReferencedLayerName" type="QString"/>
+            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
+            <Option value="studyarea_assetitem_assetitem_assetitem_T_Id" name="Relation" type="QString"/>
+            <Option value="false" name="ShowForm" type="bool"/>
+            <Option value="false" name="ShowOpenFormButton" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="assetitem_lg_geolssts_v2geolassets_assetitem">
+    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d" type="QString" name="ReferencedLayerId"/>
-            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studyarea_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="true" type="bool" name="ShowOpenFormButton"/>
+            <Option value="false" name="AllowAddFeatures" type="bool"/>
+            <Option value="true" name="AllowNULL" type="bool"/>
+            <Option value="false" name="MapIdentification" type="bool"/>
+            <Option value="true" name="OrderByValue" type="bool"/>
+            <Option value="false" name="ReadOnly" type="bool"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" name="ReferencedLayerDataSource" type="QString"/>
+            <Option value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d" name="ReferencedLayerId" type="QString"/>
+            <Option value="AssetItem" name="ReferencedLayerName" type="QString"/>
+            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
+            <Option value="studyarea_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" name="Relation" type="QString"/>
+            <Option value="false" name="ShowForm" type="bool"/>
+            <Option value="true" name="ShowOpenFormButton" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -800,28 +931,28 @@
     <alias field="assetitem_lg_geolssts_v2geolassets_assetitem" index="5" name="AssetItem"/>
   </aliases>
   <defaults>
-    <default expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" field="T_Id" applyOnUpdate="0"/>
-    <default expression="@default_basket_lg_geolassets_v2_geolassets" field="T_basket" applyOnUpdate="0"/>
-    <default expression="substr(uuid(), 2, 36)" field="T_Ili_Tid" applyOnUpdate="0"/>
-    <default expression="" field="geomquality" applyOnUpdate="0"/>
-    <default expression="" field="assetitem_assetitem" applyOnUpdate="0"/>
-    <default expression="" field="assetitem_lg_geolssts_v2geolassets_assetitem" applyOnUpdate="0"/>
+    <default field="T_Id" applyOnUpdate="0" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
+    <default field="T_basket" applyOnUpdate="0" expression="@default_basket_lg_geolassets_v2_geolassets"/>
+    <default field="T_Ili_Tid" applyOnUpdate="0" expression="substr(uuid(), 2, 36)"/>
+    <default field="geomquality" applyOnUpdate="0" expression=""/>
+    <default field="assetitem_assetitem" applyOnUpdate="0" expression=""/>
+    <default field="assetitem_lg_geolssts_v2geolassets_assetitem" applyOnUpdate="0" expression=""/>
   </defaults>
   <constraints>
-    <constraint field="T_Id" exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3"/>
-    <constraint field="T_basket" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
-    <constraint field="T_Ili_Tid" exp_strength="0" unique_strength="1" notnull_strength="0" constraints="2"/>
-    <constraint field="geomquality" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
-    <constraint field="assetitem_assetitem" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
-    <constraint field="assetitem_lg_geolssts_v2geolassets_assetitem" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint field="T_Id" notnull_strength="1" unique_strength="1" exp_strength="0" constraints="3"/>
+    <constraint field="T_basket" notnull_strength="1" unique_strength="0" exp_strength="0" constraints="1"/>
+    <constraint field="T_Ili_Tid" notnull_strength="0" unique_strength="1" exp_strength="0" constraints="2"/>
+    <constraint field="geomquality" notnull_strength="0" unique_strength="0" exp_strength="0" constraints="0"/>
+    <constraint field="assetitem_assetitem" notnull_strength="0" unique_strength="0" exp_strength="0" constraints="0"/>
+    <constraint field="assetitem_lg_geolssts_v2geolassets_assetitem" notnull_strength="1" unique_strength="0" exp_strength="0" constraints="1"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="T_Id" desc=""/>
-    <constraint exp="" field="T_basket" desc=""/>
-    <constraint exp="" field="T_Ili_Tid" desc=""/>
-    <constraint exp="" field="geomquality" desc=""/>
-    <constraint exp="" field="assetitem_assetitem" desc=""/>
-    <constraint exp="" field="assetitem_lg_geolssts_v2geolassets_assetitem" desc=""/>
+    <constraint field="T_Id" desc="" exp=""/>
+    <constraint field="T_basket" desc="" exp=""/>
+    <constraint field="T_Ili_Tid" desc="" exp=""/>
+    <constraint field="geomquality" desc="" exp=""/>
+    <constraint field="assetitem_assetitem" desc="" exp=""/>
+    <constraint field="assetitem_lg_geolssts_v2geolassets_assetitem" desc="" exp=""/>
   </constraintExpressions>
   <expressionfields/>
   <editform tolerant="1"></editform>
@@ -846,8 +977,8 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField index="3" showLabel="1" name="geomquality"/>
-    <attributeEditorField index="5" showLabel="1" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <attributeEditorField index="3" name="geomquality" showLabel="1"/>
+    <attributeEditorField index="5" name="assetitem_lg_geolssts_v2geolassets_assetitem" showLabel="1"/>
   </attributeEditorForm>
   <editable>
     <field editable="1" name="T_Id"/>
@@ -866,12 +997,12 @@ def my_form_open(dialog, layer, feature):
     <field labelOnTop="0" name="geomquality"/>
   </labelOnTop>
   <reuseLastValue>
-    <field reuseLastValue="0" name="T_Id"/>
-    <field reuseLastValue="0" name="T_Ili_Tid"/>
-    <field reuseLastValue="0" name="T_basket"/>
-    <field reuseLastValue="0" name="assetitem_assetitem"/>
-    <field reuseLastValue="0" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
-    <field reuseLastValue="0" name="geomquality"/>
+    <field name="T_Id" reuseLastValue="0"/>
+    <field name="T_Ili_Tid" reuseLastValue="0"/>
+    <field name="T_basket" reuseLastValue="0"/>
+    <field name="assetitem_assetitem" reuseLastValue="0"/>
+    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" reuseLastValue="0"/>
+    <field name="geomquality" reuseLastValue="0"/>
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>

--- a/lg_geolassets_v2/layerstyle/studylocation.qml
+++ b/lg_geolassets_v2/layerstyle/studylocation.qml
@@ -6,183 +6,183 @@
     <Searchable>1</Searchable>
     <Private>0</Private>
   </flags>
-  <renderer-v2 forceraster="0" type="RuleRenderer" enableorderby="0" referencescale="-1" symbollevels="0">
+  <renderer-v2 enableorderby="0" referencescale="-1" symbollevels="0" forceraster="0" type="RuleRenderer">
     <rules key="{d2c54199-a9a7-40a5-9328-5cb98b803b3d}">
-      <rule filter="ELSE" symbol="0" label="Not Available" key="{e337de7f-e7ff-420b-bfcd-d2d3fd1ac48d}"/>
-      <rule filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " symbol="1" label="Internal" key="{a8811e40-3dcb-4805-b5d6-f670c4ea90ba}"/>
-      <rule filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" symbol="2" label="Public" key="{6d43b524-1bf3-4143-bc63-40fefb8e9e03}"/>
+      <rule symbol="0" filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{6d43b524-1bf3-4143-bc63-40fefb8e9e03}" label="Public"/>
+      <rule symbol="1" filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') &#xa;AND NOT attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{780558a6-ddd8-403e-b37b-8ba573445624}" label="Internal"/>
+      <rule symbol="2" filter="ELSE" key="{61e7156f-e45c-49db-85fc-063d66873a1c}" label="Not Available"/>
     </rules>
     <symbols>
-      <symbol force_rhr="0" alpha="1" type="marker" clip_to_extent="1" name="0">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="0" type="marker">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
+        <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="angle"/>
-            <Option value="square" type="QString" name="cap_style"/>
-            <Option value="246,71,137,255" type="QString" name="color"/>
-            <Option value="1" type="QString" name="horizontal_anchor_point"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="circle" type="QString" name="name"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,255" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0" type="QString" name="outline_width"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="diameter" type="QString" name="scale_method"/>
-            <Option value="2.6" type="QString" name="size"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
-            <Option value="MM" type="QString" name="size_unit"/>
-            <Option value="1" type="QString" name="vertical_anchor_point"/>
+            <Option value="0" name="angle" type="QString"/>
+            <Option value="square" name="cap_style" type="QString"/>
+            <Option value="218,253,216,255" name="color" type="QString"/>
+            <Option value="1" name="horizontal_anchor_point" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="circle" name="name" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,255" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0" name="outline_width" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="diameter" name="scale_method" type="QString"/>
+            <Option value="2.6" name="size" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+            <Option value="MM" name="size_unit" type="QString"/>
+            <Option value="1" name="vertical_anchor_point" type="QString"/>
           </Option>
-          <prop v="0" k="angle"/>
-          <prop v="square" k="cap_style"/>
-          <prop v="246,71,137,255" k="color"/>
-          <prop v="1" k="horizontal_anchor_point"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="circle" k="name"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0" k="outline_width"/>
-          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="diameter" k="scale_method"/>
-          <prop v="2.6" k="size"/>
-          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-          <prop v="MM" k="size_unit"/>
-          <prop v="1" k="vertical_anchor_point"/>
+          <prop k="angle" v="0"/>
+          <prop k="cap_style" v="square"/>
+          <prop k="color" v="218,253,216,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="2.6"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="marker" clip_to_extent="1" name="1">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="1" type="marker">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
+        <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="angle"/>
-            <Option value="square" type="QString" name="cap_style"/>
-            <Option value="254,209,147,255" type="QString" name="color"/>
-            <Option value="1" type="QString" name="horizontal_anchor_point"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="circle" type="QString" name="name"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,255" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0" type="QString" name="outline_width"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="diameter" type="QString" name="scale_method"/>
-            <Option value="2.6" type="QString" name="size"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
-            <Option value="MM" type="QString" name="size_unit"/>
-            <Option value="1" type="QString" name="vertical_anchor_point"/>
+            <Option value="0" name="angle" type="QString"/>
+            <Option value="square" name="cap_style" type="QString"/>
+            <Option value="254,209,147,255" name="color" type="QString"/>
+            <Option value="1" name="horizontal_anchor_point" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="circle" name="name" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,255" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0" name="outline_width" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="diameter" name="scale_method" type="QString"/>
+            <Option value="2.6" name="size" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+            <Option value="MM" name="size_unit" type="QString"/>
+            <Option value="1" name="vertical_anchor_point" type="QString"/>
           </Option>
-          <prop v="0" k="angle"/>
-          <prop v="square" k="cap_style"/>
-          <prop v="254,209,147,255" k="color"/>
-          <prop v="1" k="horizontal_anchor_point"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="circle" k="name"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0" k="outline_width"/>
-          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="diameter" k="scale_method"/>
-          <prop v="2.6" k="size"/>
-          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-          <prop v="MM" k="size_unit"/>
-          <prop v="1" k="vertical_anchor_point"/>
+          <prop k="angle" v="0"/>
+          <prop k="cap_style" v="square"/>
+          <prop k="color" v="254,209,147,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="2.6"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="marker" clip_to_extent="1" name="2">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="2" type="marker">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
+        <layer pass="0" class="SimpleMarker" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="angle"/>
-            <Option value="square" type="QString" name="cap_style"/>
-            <Option value="218,253,216,255" type="QString" name="color"/>
-            <Option value="1" type="QString" name="horizontal_anchor_point"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="circle" type="QString" name="name"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,255" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0" type="QString" name="outline_width"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="diameter" type="QString" name="scale_method"/>
-            <Option value="2.6" type="QString" name="size"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
-            <Option value="MM" type="QString" name="size_unit"/>
-            <Option value="1" type="QString" name="vertical_anchor_point"/>
+            <Option value="0" name="angle" type="QString"/>
+            <Option value="square" name="cap_style" type="QString"/>
+            <Option value="246,71,137,255" name="color" type="QString"/>
+            <Option value="1" name="horizontal_anchor_point" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="circle" name="name" type="QString"/>
+            <Option value="0,0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0,0,0,255" name="outline_color" type="QString"/>
+            <Option value="solid" name="outline_style" type="QString"/>
+            <Option value="0" name="outline_width" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+            <Option value="MM" name="outline_width_unit" type="QString"/>
+            <Option value="diameter" name="scale_method" type="QString"/>
+            <Option value="2.6" name="size" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+            <Option value="MM" name="size_unit" type="QString"/>
+            <Option value="1" name="vertical_anchor_point" type="QString"/>
           </Option>
-          <prop v="0" k="angle"/>
-          <prop v="square" k="cap_style"/>
-          <prop v="218,253,216,255" k="color"/>
-          <prop v="1" k="horizontal_anchor_point"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="circle" k="name"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0" k="outline_width"/>
-          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="diameter" k="scale_method"/>
-          <prop v="2.6" k="size"/>
-          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-          <prop v="MM" k="size_unit"/>
-          <prop v="1" k="vertical_anchor_point"/>
+          <prop k="angle" v="0"/>
+          <prop k="cap_style" v="square"/>
+          <prop k="color" v="246,71,137,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="2.6"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -191,17 +191,17 @@
   </renderer-v2>
   <customproperties>
     <Option type="Map">
-      <Option value="copy" type="QString" name="QFieldSync/action"/>
-      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
-      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
-      <Option type="List" name="dualview/previewExpressions">
+      <Option value="copy" name="QFieldSync/action" type="QString"/>
+      <Option value="offline" name="QFieldSync/cloud_action" type="QString"/>
+      <Option value="{}" name="QFieldSync/photo_naming" type="QString"/>
+      <Option name="dualview/previewExpressions" type="List">
         <Option value="if(length(geom_to_wkt( $geometry ))>22,substr(geom_to_wkt( $geometry ),0,23)||'...',geom_to_wkt( $geometry ))" type="QString"/>
       </Option>
-      <Option value="0" type="int" name="embeddedWidgets/count"/>
-      <Option type="StringList" name="variableNames">
+      <Option value="0" name="embeddedWidgets/count" type="int"/>
+      <Option name="variableNames" type="StringList">
         <Option value="interlis_topic" type="QString"/>
       </Option>
-      <Option type="StringList" name="variableValues">
+      <Option name="variableValues" type="StringList">
         <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
       </Option>
     </Option>
@@ -209,105 +209,105 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id">
+    <field name="T_Id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_basket">
+    <field name="T_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="false" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="&quot;topic&quot; = 'LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" type="QString" name="ReferencedLayerId"/>
-            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studylocation_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option value="false" name="AllowAddFeatures" type="bool"/>
+            <Option value="false" name="AllowNULL" type="bool"/>
+            <Option value="false" name="ChainFilters" type="bool"/>
+            <Option value="&quot;topic&quot; = 'LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" name="FilterExpression" type="QString"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option value="false" name="MapIdentification" type="bool"/>
+            <Option value="true" name="OrderByValue" type="bool"/>
+            <Option value="false" name="ReadOnly" type="bool"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" name="ReferencedLayerDataSource" type="QString"/>
+            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" name="ReferencedLayerId" type="QString"/>
+            <Option value="T_ILI2DB_BASKET" name="ReferencedLayerName" type="QString"/>
+            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
+            <Option value="studylocation_T_basket_T_ILI2DB_BASKET_T_Id" name="Relation" type="QString"/>
+            <Option value="false" name="ShowForm" type="bool"/>
+            <Option value="false" name="ShowOpenFormButton" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_Ili_Tid">
+    <field name="T_Ili_Tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="geomquality">
+    <field name="geomquality" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_4/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8" type="QString" name="ReferencedLayerId"/>
-            <Option value="GeomQualityItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studylocation_geomquality_geomqualityitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option value="false" name="AllowAddFeatures" type="bool"/>
+            <Option value="true" name="AllowNULL" type="bool"/>
+            <Option value="false" name="ChainFilters" type="bool"/>
+            <Option value="" name="FilterExpression" type="QString"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option value="false" name="MapIdentification" type="bool"/>
+            <Option value="true" name="OrderByValue" type="bool"/>
+            <Option value="false" name="ReadOnly" type="bool"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_4/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem" name="ReferencedLayerDataSource" type="QString"/>
+            <Option value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8" name="ReferencedLayerId" type="QString"/>
+            <Option value="GeomQualityItem" name="ReferencedLayerName" type="QString"/>
+            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
+            <Option value="studylocation_geomquality_geomqualityitem_T_Id" name="Relation" type="QString"/>
+            <Option value="false" name="ShowForm" type="bool"/>
+            <Option value="false" name="ShowOpenFormButton" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="assetitem_assetitem">
+    <field name="assetitem_assetitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="true" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e" type="QString" name="ReferencedLayerId"/>
-            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studylocation_assetitem_assetitem_assetitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option value="true" name="AllowAddFeatures" type="bool"/>
+            <Option value="true" name="AllowNULL" type="bool"/>
+            <Option value="false" name="MapIdentification" type="bool"/>
+            <Option value="true" name="OrderByValue" type="bool"/>
+            <Option value="false" name="ReadOnly" type="bool"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem" name="ReferencedLayerDataSource" type="QString"/>
+            <Option value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e" name="ReferencedLayerId" type="QString"/>
+            <Option value="AssetItem" name="ReferencedLayerName" type="QString"/>
+            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
+            <Option value="studylocation_assetitem_assetitem_assetitem_T_Id" name="Relation" type="QString"/>
+            <Option value="false" name="ShowForm" type="bool"/>
+            <Option value="false" name="ShowOpenFormButton" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="assetitem_lg_geolssts_v2geolassets_assetitem">
+    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d" type="QString" name="ReferencedLayerId"/>
-            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studylocation_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="true" type="bool" name="ShowOpenFormButton"/>
+            <Option value="false" name="AllowAddFeatures" type="bool"/>
+            <Option value="true" name="AllowNULL" type="bool"/>
+            <Option value="false" name="MapIdentification" type="bool"/>
+            <Option value="true" name="OrderByValue" type="bool"/>
+            <Option value="false" name="ReadOnly" type="bool"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" name="ReferencedLayerDataSource" type="QString"/>
+            <Option value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d" name="ReferencedLayerId" type="QString"/>
+            <Option value="AssetItem" name="ReferencedLayerName" type="QString"/>
+            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
+            <Option value="studylocation_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" name="Relation" type="QString"/>
+            <Option value="false" name="ShowForm" type="bool"/>
+            <Option value="true" name="ShowOpenFormButton" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -322,28 +322,28 @@
     <alias field="assetitem_lg_geolssts_v2geolassets_assetitem" index="5" name="AssetItem"/>
   </aliases>
   <defaults>
-    <default expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" field="T_Id" applyOnUpdate="0"/>
-    <default expression="@default_basket_lg_geolassets_v2_geolassets" field="T_basket" applyOnUpdate="0"/>
-    <default expression="substr(uuid(), 2, 36)" field="T_Ili_Tid" applyOnUpdate="0"/>
-    <default expression="" field="geomquality" applyOnUpdate="0"/>
-    <default expression="" field="assetitem_assetitem" applyOnUpdate="0"/>
-    <default expression="" field="assetitem_lg_geolssts_v2geolassets_assetitem" applyOnUpdate="0"/>
+    <default field="T_Id" applyOnUpdate="0" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
+    <default field="T_basket" applyOnUpdate="0" expression="@default_basket_lg_geolassets_v2_geolassets"/>
+    <default field="T_Ili_Tid" applyOnUpdate="0" expression="substr(uuid(), 2, 36)"/>
+    <default field="geomquality" applyOnUpdate="0" expression=""/>
+    <default field="assetitem_assetitem" applyOnUpdate="0" expression=""/>
+    <default field="assetitem_lg_geolssts_v2geolassets_assetitem" applyOnUpdate="0" expression=""/>
   </defaults>
   <constraints>
-    <constraint field="T_Id" exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3"/>
-    <constraint field="T_basket" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
-    <constraint field="T_Ili_Tid" exp_strength="0" unique_strength="1" notnull_strength="0" constraints="2"/>
-    <constraint field="geomquality" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
-    <constraint field="assetitem_assetitem" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
-    <constraint field="assetitem_lg_geolssts_v2geolassets_assetitem" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint field="T_Id" notnull_strength="1" unique_strength="1" exp_strength="0" constraints="3"/>
+    <constraint field="T_basket" notnull_strength="1" unique_strength="0" exp_strength="0" constraints="1"/>
+    <constraint field="T_Ili_Tid" notnull_strength="0" unique_strength="1" exp_strength="0" constraints="2"/>
+    <constraint field="geomquality" notnull_strength="0" unique_strength="0" exp_strength="0" constraints="0"/>
+    <constraint field="assetitem_assetitem" notnull_strength="0" unique_strength="0" exp_strength="0" constraints="0"/>
+    <constraint field="assetitem_lg_geolssts_v2geolassets_assetitem" notnull_strength="1" unique_strength="0" exp_strength="0" constraints="1"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="T_Id" desc=""/>
-    <constraint exp="" field="T_basket" desc=""/>
-    <constraint exp="" field="T_Ili_Tid" desc=""/>
-    <constraint exp="" field="geomquality" desc=""/>
-    <constraint exp="" field="assetitem_assetitem" desc=""/>
-    <constraint exp="" field="assetitem_lg_geolssts_v2geolassets_assetitem" desc=""/>
+    <constraint field="T_Id" desc="" exp=""/>
+    <constraint field="T_basket" desc="" exp=""/>
+    <constraint field="T_Ili_Tid" desc="" exp=""/>
+    <constraint field="geomquality" desc="" exp=""/>
+    <constraint field="assetitem_assetitem" desc="" exp=""/>
+    <constraint field="assetitem_lg_geolssts_v2geolassets_assetitem" desc="" exp=""/>
   </constraintExpressions>
   <expressionfields/>
   <editform tolerant="1"></editform>
@@ -368,8 +368,8 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField index="3" showLabel="1" name="geomquality"/>
-    <attributeEditorField index="5" showLabel="1" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <attributeEditorField index="3" name="geomquality" showLabel="1"/>
+    <attributeEditorField index="5" name="assetitem_lg_geolssts_v2geolassets_assetitem" showLabel="1"/>
   </attributeEditorForm>
   <editable>
     <field editable="1" name="T_Id"/>
@@ -388,12 +388,12 @@ def my_form_open(dialog, layer, feature):
     <field labelOnTop="0" name="geomquality"/>
   </labelOnTop>
   <reuseLastValue>
-    <field reuseLastValue="0" name="T_Id"/>
-    <field reuseLastValue="0" name="T_Ili_Tid"/>
-    <field reuseLastValue="0" name="T_basket"/>
-    <field reuseLastValue="0" name="assetitem_assetitem"/>
-    <field reuseLastValue="0" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
-    <field reuseLastValue="0" name="geomquality"/>
+    <field name="T_Id" reuseLastValue="0"/>
+    <field name="T_Ili_Tid" reuseLastValue="0"/>
+    <field name="T_basket" reuseLastValue="0"/>
+    <field name="assetitem_assetitem" reuseLastValue="0"/>
+    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" reuseLastValue="0"/>
+    <field name="geomquality" reuseLastValue="0"/>
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>

--- a/lg_geolassets_v2/layerstyle/studylocation.qml
+++ b/lg_geolassets_v2/layerstyle/studylocation.qml
@@ -1,188 +1,188 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="LayerConfiguration|Symbology|Fields|Forms|CustomProperties" readOnly="0" version="3.24.3-Tisler">
+<qgis readOnly="0" version="3.22.11-Białowieża" styleCategories="LayerConfiguration|Symbology|Fields|Forms|CustomProperties">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
     <Private>0</Private>
   </flags>
-  <renderer-v2 type="RuleRenderer" referencescale="-1" symbollevels="0" enableorderby="0" forceraster="0">
+  <renderer-v2 forceraster="0" type="RuleRenderer" enableorderby="0" referencescale="-1" symbollevels="0">
     <rules key="{d2c54199-a9a7-40a5-9328-5cb98b803b3d}">
-      <rule label="Public" symbol="0" filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{71159bf5-027c-46b0-9c0a-cca14e76d58b}"/>
-      <rule label="Internal" symbol="1" filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " key="{71159bf5-027c-46b0-9c0a-cca14e76d58b}"/>
-      <rule label="Not Available" symbol="2" filter="ELSE" key="{e337de7f-e7ff-420b-bfcd-d2d3fd1ac48d}"/>
+      <rule filter="ELSE" symbol="0" label="Not Available" key="{e337de7f-e7ff-420b-bfcd-d2d3fd1ac48d}"/>
+      <rule filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " symbol="1" label="Internal" key="{a8811e40-3dcb-4805-b5d6-f670c4ea90ba}"/>
+      <rule filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" symbol="2" label="Public" key="{6d43b524-1bf3-4143-bc63-40fefb8e9e03}"/>
     </rules>
     <symbols>
-      <symbol name="0" type="marker" clip_to_extent="1" force_rhr="0" alpha="1">
+      <symbol force_rhr="0" alpha="1" type="marker" clip_to_extent="1" name="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleMarker" locked="0" pass="0" enabled="1">
+        <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
           <Option type="Map">
-            <Option name="angle" type="QString" value="0"/>
-            <Option name="cap_style" type="QString" value="square"/>
-            <Option name="color" type="QString" value="218,253,216,255"/>
-            <Option name="horizontal_anchor_point" type="QString" value="1"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="name" type="QString" value="circle"/>
-            <Option name="offset" type="QString" value="0,0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="outline_color" type="QString" value="0,0,0,255"/>
-            <Option name="outline_style" type="QString" value="solid"/>
-            <Option name="outline_width" type="QString" value="0"/>
-            <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="outline_width_unit" type="QString" value="MM"/>
-            <Option name="scale_method" type="QString" value="diameter"/>
-            <Option name="size" type="QString" value="2.6"/>
-            <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="size_unit" type="QString" value="MM"/>
-            <Option name="vertical_anchor_point" type="QString" value="1"/>
+            <Option value="0" type="QString" name="angle"/>
+            <Option value="square" type="QString" name="cap_style"/>
+            <Option value="246,71,137,255" type="QString" name="color"/>
+            <Option value="1" type="QString" name="horizontal_anchor_point"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="circle" type="QString" name="name"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0" type="QString" name="outline_width"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="diameter" type="QString" name="scale_method"/>
+            <Option value="2.6" type="QString" name="size"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+            <Option value="MM" type="QString" name="size_unit"/>
+            <Option value="1" type="QString" name="vertical_anchor_point"/>
           </Option>
-          <prop k="angle" v="0"/>
-          <prop k="cap_style" v="square"/>
-          <prop k="color" v="218,253,216,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="circle"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="0,0,0,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="diameter"/>
-          <prop k="size" v="2.6"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+          <prop v="0" k="angle"/>
+          <prop v="square" k="cap_style"/>
+          <prop v="246,71,137,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="circle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="2.6" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MM" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="1" type="marker" clip_to_extent="1" force_rhr="0" alpha="1">
+      <symbol force_rhr="0" alpha="1" type="marker" clip_to_extent="1" name="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleMarker" locked="0" pass="0" enabled="1">
+        <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
           <Option type="Map">
-            <Option name="angle" type="QString" value="0"/>
-            <Option name="cap_style" type="QString" value="square"/>
-            <Option name="color" type="QString" value="254,209,147,255"/>
-            <Option name="horizontal_anchor_point" type="QString" value="1"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="name" type="QString" value="circle"/>
-            <Option name="offset" type="QString" value="0,0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="outline_color" type="QString" value="0,0,0,255"/>
-            <Option name="outline_style" type="QString" value="solid"/>
-            <Option name="outline_width" type="QString" value="0"/>
-            <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="outline_width_unit" type="QString" value="MM"/>
-            <Option name="scale_method" type="QString" value="diameter"/>
-            <Option name="size" type="QString" value="2.6"/>
-            <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="size_unit" type="QString" value="MM"/>
-            <Option name="vertical_anchor_point" type="QString" value="1"/>
+            <Option value="0" type="QString" name="angle"/>
+            <Option value="square" type="QString" name="cap_style"/>
+            <Option value="254,209,147,255" type="QString" name="color"/>
+            <Option value="1" type="QString" name="horizontal_anchor_point"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="circle" type="QString" name="name"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0" type="QString" name="outline_width"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="diameter" type="QString" name="scale_method"/>
+            <Option value="2.6" type="QString" name="size"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+            <Option value="MM" type="QString" name="size_unit"/>
+            <Option value="1" type="QString" name="vertical_anchor_point"/>
           </Option>
-          <prop k="angle" v="0"/>
-          <prop k="cap_style" v="square"/>
-          <prop k="color" v="254,209,147,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="circle"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="0,0,0,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="diameter"/>
-          <prop k="size" v="2.6"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+          <prop v="0" k="angle"/>
+          <prop v="square" k="cap_style"/>
+          <prop v="254,209,147,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="circle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="2.6" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MM" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" type="marker" clip_to_extent="1" force_rhr="0" alpha="1">
+      <symbol force_rhr="0" alpha="1" type="marker" clip_to_extent="1" name="2">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleMarker" locked="0" pass="0" enabled="1">
+        <layer enabled="1" pass="0" class="SimpleMarker" locked="0">
           <Option type="Map">
-            <Option name="angle" type="QString" value="0"/>
-            <Option name="cap_style" type="QString" value="square"/>
-            <Option name="color" type="QString" value="246,71,137,255"/>
-            <Option name="horizontal_anchor_point" type="QString" value="1"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="name" type="QString" value="circle"/>
-            <Option name="offset" type="QString" value="0,0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="outline_color" type="QString" value="0,0,0,255"/>
-            <Option name="outline_style" type="QString" value="solid"/>
-            <Option name="outline_width" type="QString" value="0"/>
-            <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="outline_width_unit" type="QString" value="MM"/>
-            <Option name="scale_method" type="QString" value="diameter"/>
-            <Option name="size" type="QString" value="2.6"/>
-            <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="size_unit" type="QString" value="MM"/>
-            <Option name="vertical_anchor_point" type="QString" value="1"/>
+            <Option value="0" type="QString" name="angle"/>
+            <Option value="square" type="QString" name="cap_style"/>
+            <Option value="218,253,216,255" type="QString" name="color"/>
+            <Option value="1" type="QString" name="horizontal_anchor_point"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="circle" type="QString" name="name"/>
+            <Option value="0,0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0,0,0,255" type="QString" name="outline_color"/>
+            <Option value="solid" type="QString" name="outline_style"/>
+            <Option value="0" type="QString" name="outline_width"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
+            <Option value="MM" type="QString" name="outline_width_unit"/>
+            <Option value="diameter" type="QString" name="scale_method"/>
+            <Option value="2.6" type="QString" name="size"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
+            <Option value="MM" type="QString" name="size_unit"/>
+            <Option value="1" type="QString" name="vertical_anchor_point"/>
           </Option>
-          <prop k="angle" v="0"/>
-          <prop k="cap_style" v="square"/>
-          <prop k="color" v="246,71,137,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="circle"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="0,0,0,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="diameter"/>
-          <prop k="size" v="2.6"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+          <prop v="0" k="angle"/>
+          <prop v="square" k="cap_style"/>
+          <prop v="218,253,216,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="circle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0,0,0,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MM" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="2.6" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MM" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -191,151 +191,151 @@
   </renderer-v2>
   <customproperties>
     <Option type="Map">
-      <Option name="QFieldSync/action" type="QString" value="copy"/>
-      <Option name="QFieldSync/cloud_action" type="QString" value="offline"/>
-      <Option name="QFieldSync/photo_naming" type="QString" value="{}"/>
-      <Option name="dualview/previewExpressions" type="List">
-        <Option type="QString" value="if(length(geom_to_wkt( $geometry ))>22,substr(geom_to_wkt( $geometry ),0,23)||'...',geom_to_wkt( $geometry ))"/>
+      <Option value="copy" type="QString" name="QFieldSync/action"/>
+      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
+      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
+      <Option type="List" name="dualview/previewExpressions">
+        <Option value="if(length(geom_to_wkt( $geometry ))>22,substr(geom_to_wkt( $geometry ),0,23)||'...',geom_to_wkt( $geometry ))" type="QString"/>
       </Option>
-      <Option name="embeddedWidgets/count" type="int" value="0"/>
-      <Option name="variableNames" type="StringList">
-        <Option type="QString" value="interlis_topic"/>
+      <Option value="0" type="int" name="embeddedWidgets/count"/>
+      <Option type="StringList" name="variableNames">
+        <Option value="interlis_topic" type="QString"/>
       </Option>
-      <Option name="variableValues" type="StringList">
-        <Option type="QString" value="LG_GeolAssets_V2.GeolAssets"/>
+      <Option type="StringList" name="variableValues">
+        <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
       </Option>
     </Option>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <fieldConfiguration>
-    <field name="T_Id" configurationFlags="None">
+    <field configurationFlags="None" name="T_Id">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="T_basket" configurationFlags="None">
+    <field configurationFlags="None" name="T_basket">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="ChainFilters" type="bool" value="false"/>
-            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; = 'LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
-            <Option name="FilterFields" type="invalid"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="true"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c"/>
-            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="studylocation_T_basket_T_ILI2DB_BASKET_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="false"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="ChainFilters"/>
+            <Option value="&quot;topic&quot; = 'LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString" name="FilterExpression"/>
+            <Option type="invalid" name="FilterFields"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="true" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" type="QString" name="ReferencedLayerId"/>
+            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="studylocation_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="false" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="T_Ili_Tid" configurationFlags="None">
+    <field configurationFlags="None" name="T_Ili_Tid">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="geomquality" configurationFlags="None">
+    <field configurationFlags="None" name="geomquality">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="true"/>
-            <Option name="ChainFilters" type="bool" value="false"/>
-            <Option name="FilterExpression" type="QString" value=""/>
-            <Option name="FilterFields" type="invalid"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="true"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2_4/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8"/>
-            <Option name="ReferencedLayerName" type="QString" value="GeomQualityItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="studylocation_geomquality_geomqualityitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="false"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="true" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="ChainFilters"/>
+            <Option value="" type="QString" name="FilterExpression"/>
+            <Option type="invalid" name="FilterFields"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="true" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_4/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8" type="QString" name="ReferencedLayerId"/>
+            <Option value="GeomQualityItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="studylocation_geomquality_geomqualityitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="false" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="assetitem_assetitem" configurationFlags="None">
+    <field configurationFlags="None" name="assetitem_assetitem">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="true"/>
-            <Option name="AllowNULL" type="bool" value="true"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="true"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e"/>
-            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="studylocation_assetitem_assetitem_assetitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="false"/>
+            <Option value="true" type="bool" name="AllowAddFeatures"/>
+            <Option value="true" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="true" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e" type="QString" name="ReferencedLayerId"/>
+            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="studylocation_assetitem_assetitem_assetitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="false" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" configurationFlags="None">
+    <field configurationFlags="None" name="assetitem_lg_geolssts_v2geolassets_assetitem">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="true"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="true"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
-            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="studylocation_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="true" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="true" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d" type="QString" name="ReferencedLayerId"/>
+            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="studylocation_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="T_Id"/>
-    <alias name="" index="1" field="T_basket"/>
-    <alias name="" index="2" field="T_Ili_Tid"/>
-    <alias name="Qualität" index="3" field="geomquality"/>
-    <alias name="AssetItem" index="4" field="assetitem_assetitem"/>
-    <alias name="AssetItem" index="5" field="assetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <alias field="T_Id" index="0" name=""/>
+    <alias field="T_basket" index="1" name=""/>
+    <alias field="T_Ili_Tid" index="2" name=""/>
+    <alias field="geomquality" index="3" name="Qualität"/>
+    <alias field="assetitem_assetitem" index="4" name="AssetItem"/>
+    <alias field="assetitem_lg_geolssts_v2geolassets_assetitem" index="5" name="AssetItem"/>
   </aliases>
   <defaults>
-    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
-    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
-    <default applyOnUpdate="0" field="T_Ili_Tid" expression="substr(uuid(), 2, 36)"/>
-    <default applyOnUpdate="0" field="geomquality" expression=""/>
-    <default applyOnUpdate="0" field="assetitem_assetitem" expression=""/>
-    <default applyOnUpdate="0" field="assetitem_lg_geolssts_v2geolassets_assetitem" expression=""/>
+    <default expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" field="T_Id" applyOnUpdate="0"/>
+    <default expression="@default_basket_lg_geolassets_v2_geolassets" field="T_basket" applyOnUpdate="0"/>
+    <default expression="substr(uuid(), 2, 36)" field="T_Ili_Tid" applyOnUpdate="0"/>
+    <default expression="" field="geomquality" applyOnUpdate="0"/>
+    <default expression="" field="assetitem_assetitem" applyOnUpdate="0"/>
+    <default expression="" field="assetitem_lg_geolssts_v2geolassets_assetitem" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="1" constraints="2" field="T_Ili_Tid" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="geomquality" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="assetitem_assetitem" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" field="assetitem_lg_geolssts_v2geolassets_assetitem" notnull_strength="1" exp_strength="0"/>
+    <constraint field="T_Id" exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3"/>
+    <constraint field="T_basket" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint field="T_Ili_Tid" exp_strength="0" unique_strength="1" notnull_strength="0" constraints="2"/>
+    <constraint field="geomquality" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="assetitem_assetitem" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="assetitem_lg_geolssts_v2geolassets_assetitem" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="T_Id" desc=""/>
@@ -368,24 +368,24 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField name="geomquality" index="3" showLabel="1"/>
-    <attributeEditorField name="assetitem_lg_geolssts_v2geolassets_assetitem" index="5" showLabel="1"/>
+    <attributeEditorField index="3" showLabel="1" name="geomquality"/>
+    <attributeEditorField index="5" showLabel="1" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
   </attributeEditorForm>
   <editable>
-    <field name="T_Id" editable="1"/>
-    <field name="T_Ili_Tid" editable="1"/>
-    <field name="T_basket" editable="1"/>
-    <field name="assetitem_assetitem" editable="1"/>
-    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" editable="0"/>
-    <field name="geomquality" editable="1"/>
+    <field editable="1" name="T_Id"/>
+    <field editable="1" name="T_Ili_Tid"/>
+    <field editable="1" name="T_basket"/>
+    <field editable="1" name="assetitem_assetitem"/>
+    <field editable="0" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <field editable="1" name="geomquality"/>
   </editable>
   <labelOnTop>
-    <field name="T_Id" labelOnTop="0"/>
-    <field name="T_Ili_Tid" labelOnTop="0"/>
-    <field name="T_basket" labelOnTop="0"/>
-    <field name="assetitem_assetitem" labelOnTop="0"/>
-    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" labelOnTop="0"/>
-    <field name="geomquality" labelOnTop="0"/>
+    <field labelOnTop="0" name="T_Id"/>
+    <field labelOnTop="0" name="T_Ili_Tid"/>
+    <field labelOnTop="0" name="T_basket"/>
+    <field labelOnTop="0" name="assetitem_assetitem"/>
+    <field labelOnTop="0" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <field labelOnTop="0" name="geomquality"/>
   </labelOnTop>
   <reuseLastValue>
     <field reuseLastValue="0" name="T_Id"/>

--- a/lg_geolassets_v2/layerstyle/studylocation.qml
+++ b/lg_geolassets_v2/layerstyle/studylocation.qml
@@ -1,188 +1,188 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="LayerConfiguration|Symbology|Fields|Forms|CustomProperties" readOnly="0" version="3.25.0-Master">
+<qgis styleCategories="LayerConfiguration|Symbology|Fields|Forms|CustomProperties" readOnly="0" version="3.24.3-Tisler">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
     <Private>0</Private>
   </flags>
-  <renderer-v2 referencescale="-1" type="RuleRenderer" symbollevels="0" forceraster="0" enableorderby="0">
+  <renderer-v2 type="RuleRenderer" referencescale="-1" symbollevels="0" enableorderby="0" forceraster="0">
     <rules key="{d2c54199-a9a7-40a5-9328-5cb98b803b3d}">
-      <rule filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" symbol="0" key="{71159bf5-027c-46b0-9c0a-cca14e76d58b}" label="Public"/>
-      <rule filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " symbol="1" key="{71159bf5-027c-46b0-9c0a-cca14e76d58b}" label="Internal"/>
-      <rule filter="ELSE" symbol="2" key="{e337de7f-e7ff-420b-bfcd-d2d3fd1ac48d}" label="Not Available"/>
+      <rule label="Public" symbol="0" filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{71159bf5-027c-46b0-9c0a-cca14e76d58b}"/>
+      <rule label="Internal" symbol="1" filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " key="{71159bf5-027c-46b0-9c0a-cca14e76d58b}"/>
+      <rule label="Not Available" symbol="2" filter="ELSE" key="{e337de7f-e7ff-420b-bfcd-d2d3fd1ac48d}"/>
     </rules>
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" force_rhr="0" is_animated="0" type="marker" name="0" frame_rate="10">
+      <symbol name="0" type="marker" clip_to_extent="1" force_rhr="0" alpha="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option name="name" type="QString" value=""/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
         </data_defined_properties>
-        <layer pass="0" class="SimpleMarker" enabled="1" locked="0">
+        <layer class="SimpleMarker" locked="0" pass="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="angle"/>
-            <Option value="square" type="QString" name="cap_style"/>
-            <Option value="218,253,216,255" type="QString" name="color"/>
-            <Option value="1" type="QString" name="horizontal_anchor_point"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="circle" type="QString" name="name"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,255" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0" type="QString" name="outline_width"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="diameter" type="QString" name="scale_method"/>
-            <Option value="2.6" type="QString" name="size"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
-            <Option value="MM" type="QString" name="size_unit"/>
-            <Option value="1" type="QString" name="vertical_anchor_point"/>
+            <Option name="angle" type="QString" value="0"/>
+            <Option name="cap_style" type="QString" value="square"/>
+            <Option name="color" type="QString" value="218,253,216,255"/>
+            <Option name="horizontal_anchor_point" type="QString" value="1"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="name" type="QString" value="circle"/>
+            <Option name="offset" type="QString" value="0,0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="outline_color" type="QString" value="0,0,0,255"/>
+            <Option name="outline_style" type="QString" value="solid"/>
+            <Option name="outline_width" type="QString" value="0"/>
+            <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+            <Option name="scale_method" type="QString" value="diameter"/>
+            <Option name="size" type="QString" value="2.6"/>
+            <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="size_unit" type="QString" value="MM"/>
+            <Option name="vertical_anchor_point" type="QString" value="1"/>
           </Option>
-          <prop v="0" k="angle"/>
-          <prop v="square" k="cap_style"/>
-          <prop v="218,253,216,255" k="color"/>
-          <prop v="1" k="horizontal_anchor_point"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="circle" k="name"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0" k="outline_width"/>
-          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="diameter" k="scale_method"/>
-          <prop v="2.6" k="size"/>
-          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-          <prop v="MM" k="size_unit"/>
-          <prop v="1" k="vertical_anchor_point"/>
+          <prop k="angle" v="0"/>
+          <prop k="cap_style" v="square"/>
+          <prop k="color" v="218,253,216,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="2.6"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" force_rhr="0" is_animated="0" type="marker" name="1" frame_rate="10">
+      <symbol name="1" type="marker" clip_to_extent="1" force_rhr="0" alpha="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option name="name" type="QString" value=""/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
         </data_defined_properties>
-        <layer pass="0" class="SimpleMarker" enabled="1" locked="0">
+        <layer class="SimpleMarker" locked="0" pass="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="angle"/>
-            <Option value="square" type="QString" name="cap_style"/>
-            <Option value="254,209,147,255" type="QString" name="color"/>
-            <Option value="1" type="QString" name="horizontal_anchor_point"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="circle" type="QString" name="name"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,255" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0" type="QString" name="outline_width"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="diameter" type="QString" name="scale_method"/>
-            <Option value="2.6" type="QString" name="size"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
-            <Option value="MM" type="QString" name="size_unit"/>
-            <Option value="1" type="QString" name="vertical_anchor_point"/>
+            <Option name="angle" type="QString" value="0"/>
+            <Option name="cap_style" type="QString" value="square"/>
+            <Option name="color" type="QString" value="254,209,147,255"/>
+            <Option name="horizontal_anchor_point" type="QString" value="1"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="name" type="QString" value="circle"/>
+            <Option name="offset" type="QString" value="0,0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="outline_color" type="QString" value="0,0,0,255"/>
+            <Option name="outline_style" type="QString" value="solid"/>
+            <Option name="outline_width" type="QString" value="0"/>
+            <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+            <Option name="scale_method" type="QString" value="diameter"/>
+            <Option name="size" type="QString" value="2.6"/>
+            <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="size_unit" type="QString" value="MM"/>
+            <Option name="vertical_anchor_point" type="QString" value="1"/>
           </Option>
-          <prop v="0" k="angle"/>
-          <prop v="square" k="cap_style"/>
-          <prop v="254,209,147,255" k="color"/>
-          <prop v="1" k="horizontal_anchor_point"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="circle" k="name"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0" k="outline_width"/>
-          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="diameter" k="scale_method"/>
-          <prop v="2.6" k="size"/>
-          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-          <prop v="MM" k="size_unit"/>
-          <prop v="1" k="vertical_anchor_point"/>
+          <prop k="angle" v="0"/>
+          <prop k="cap_style" v="square"/>
+          <prop k="color" v="254,209,147,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="2.6"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" force_rhr="0" is_animated="0" type="marker" name="2" frame_rate="10">
+      <symbol name="2" type="marker" clip_to_extent="1" force_rhr="0" alpha="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option name="name" type="QString" value=""/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
         </data_defined_properties>
-        <layer pass="0" class="SimpleMarker" enabled="1" locked="0">
+        <layer class="SimpleMarker" locked="0" pass="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="angle"/>
-            <Option value="square" type="QString" name="cap_style"/>
-            <Option value="246,71,137,255" type="QString" name="color"/>
-            <Option value="1" type="QString" name="horizontal_anchor_point"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="circle" type="QString" name="name"/>
-            <Option value="0,0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0,0,0,255" type="QString" name="outline_color"/>
-            <Option value="solid" type="QString" name="outline_style"/>
-            <Option value="0" type="QString" name="outline_width"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="outline_width_map_unit_scale"/>
-            <Option value="MM" type="QString" name="outline_width_unit"/>
-            <Option value="diameter" type="QString" name="scale_method"/>
-            <Option value="2.6" type="QString" name="size"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="size_map_unit_scale"/>
-            <Option value="MM" type="QString" name="size_unit"/>
-            <Option value="1" type="QString" name="vertical_anchor_point"/>
+            <Option name="angle" type="QString" value="0"/>
+            <Option name="cap_style" type="QString" value="square"/>
+            <Option name="color" type="QString" value="246,71,137,255"/>
+            <Option name="horizontal_anchor_point" type="QString" value="1"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="name" type="QString" value="circle"/>
+            <Option name="offset" type="QString" value="0,0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="outline_color" type="QString" value="0,0,0,255"/>
+            <Option name="outline_style" type="QString" value="solid"/>
+            <Option name="outline_width" type="QString" value="0"/>
+            <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+            <Option name="scale_method" type="QString" value="diameter"/>
+            <Option name="size" type="QString" value="2.6"/>
+            <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="size_unit" type="QString" value="MM"/>
+            <Option name="vertical_anchor_point" type="QString" value="1"/>
           </Option>
-          <prop v="0" k="angle"/>
-          <prop v="square" k="cap_style"/>
-          <prop v="246,71,137,255" k="color"/>
-          <prop v="1" k="horizontal_anchor_point"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="circle" k="name"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0,0,0,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0" k="outline_width"/>
-          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="diameter" k="scale_method"/>
-          <prop v="2.6" k="size"/>
-          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-          <prop v="MM" k="size_unit"/>
-          <prop v="1" k="vertical_anchor_point"/>
+          <prop k="angle" v="0"/>
+          <prop k="cap_style" v="square"/>
+          <prop k="color" v="246,71,137,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="0,0,0,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="2.6"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -191,159 +191,159 @@
   </renderer-v2>
   <customproperties>
     <Option type="Map">
-      <Option value="copy" type="QString" name="QFieldSync/action"/>
-      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
-      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
-      <Option type="List" name="dualview/previewExpressions">
-        <Option value="if(length(geom_to_wkt( $geometry ))>22,substr(geom_to_wkt( $geometry ),0,23)||'...',geom_to_wkt( $geometry ))" type="QString"/>
+      <Option name="QFieldSync/action" type="QString" value="copy"/>
+      <Option name="QFieldSync/cloud_action" type="QString" value="offline"/>
+      <Option name="QFieldSync/photo_naming" type="QString" value="{}"/>
+      <Option name="dualview/previewExpressions" type="List">
+        <Option type="QString" value="if(length(geom_to_wkt( $geometry ))>22,substr(geom_to_wkt( $geometry ),0,23)||'...',geom_to_wkt( $geometry ))"/>
       </Option>
-      <Option value="0" type="int" name="embeddedWidgets/count"/>
-      <Option type="StringList" name="variableNames">
-        <Option value="interlis_topic" type="QString"/>
+      <Option name="embeddedWidgets/count" type="int" value="0"/>
+      <Option name="variableNames" type="StringList">
+        <Option type="QString" value="interlis_topic"/>
       </Option>
-      <Option type="StringList" name="variableValues">
-        <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
+      <Option name="variableValues" type="StringList">
+        <Option type="QString" value="LG_GeolAssets_V2.GeolAssets"/>
       </Option>
     </Option>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id">
+    <field name="T_Id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_basket">
+    <field name="T_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="false" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="&quot;topic&quot; = 'LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" type="QString" name="ReferencedLayerId"/>
-            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studylocation_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="ChainFilters" type="bool" value="false"/>
+            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; = 'LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c"/>
+            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="studylocation_T_basket_T_ILI2DB_BASKET_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_Ili_Tid">
+    <field name="T_Ili_Tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="geomquality">
+    <field name="geomquality" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_4/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8" type="QString" name="ReferencedLayerId"/>
-            <Option value="GeomQualityItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studylocation_geomquality_geomqualityitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="ChainFilters" type="bool" value="false"/>
+            <Option name="FilterExpression" type="QString" value=""/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2_4/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8"/>
+            <Option name="ReferencedLayerName" type="QString" value="GeomQualityItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="studylocation_geomquality_geomqualityitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="assetitem_assetitem">
+    <field name="assetitem_assetitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="true" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e" type="QString" name="ReferencedLayerId"/>
-            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studylocation_assetitem_assetitem_assetitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="true"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="studylocation_assetitem_assetitem_assetitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="assetitem_lg_geolssts_v2geolassets_assetitem">
+    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="AssetItem_655d7d08_f608_4aef_b23f_9bfc2ff514b1" type="QString" name="ReferencedLayerId"/>
-            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studylocation_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="studylocation_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="T_Id" index="0" name=""/>
-    <alias field="T_basket" index="1" name=""/>
-    <alias field="T_Ili_Tid" index="2" name=""/>
-    <alias field="geomquality" index="3" name="Qualität"/>
-    <alias field="assetitem_assetitem" index="4" name="AssetItem"/>
-    <alias field="assetitem_lg_geolssts_v2geolassets_assetitem" index="5" name="AssetItem"/>
+    <alias name="" index="0" field="T_Id"/>
+    <alias name="" index="1" field="T_basket"/>
+    <alias name="" index="2" field="T_Ili_Tid"/>
+    <alias name="Qualität" index="3" field="geomquality"/>
+    <alias name="AssetItem" index="4" field="assetitem_assetitem"/>
+    <alias name="AssetItem" index="5" field="assetitem_lg_geolssts_v2geolassets_assetitem"/>
   </aliases>
   <defaults>
-    <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
-    <default field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets" applyOnUpdate="0"/>
-    <default field="T_Ili_Tid" expression="substr(uuid(), 2, 36)" applyOnUpdate="0"/>
-    <default field="geomquality" expression="" applyOnUpdate="0"/>
-    <default field="assetitem_assetitem" expression="" applyOnUpdate="0"/>
-    <default field="assetitem_lg_geolssts_v2geolassets_assetitem" expression="" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
+    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
+    <default applyOnUpdate="0" field="T_Ili_Tid" expression="substr(uuid(), 2, 36)"/>
+    <default applyOnUpdate="0" field="geomquality" expression=""/>
+    <default applyOnUpdate="0" field="assetitem_assetitem" expression=""/>
+    <default applyOnUpdate="0" field="assetitem_lg_geolssts_v2geolassets_assetitem" expression=""/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" notnull_strength="1" field="T_Id" exp_strength="0" constraints="3"/>
-    <constraint unique_strength="0" notnull_strength="1" field="T_basket" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="T_Ili_Tid" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="geomquality" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="assetitem_assetitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="1" field="assetitem_lg_geolssts_v2geolassets_assetitem" exp_strength="0" constraints="1"/>
+    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="1" constraints="2" field="T_Ili_Tid" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="geomquality" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="assetitem_assetitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="assetitem_lg_geolssts_v2geolassets_assetitem" notnull_strength="1" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="T_Id" desc="" exp=""/>
-    <constraint field="T_basket" desc="" exp=""/>
-    <constraint field="T_Ili_Tid" desc="" exp=""/>
-    <constraint field="geomquality" desc="" exp=""/>
-    <constraint field="assetitem_assetitem" desc="" exp=""/>
-    <constraint field="assetitem_lg_geolssts_v2geolassets_assetitem" desc="" exp=""/>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="T_Ili_Tid" desc=""/>
+    <constraint exp="" field="geomquality" desc=""/>
+    <constraint exp="" field="assetitem_assetitem" desc=""/>
+    <constraint exp="" field="assetitem_lg_geolssts_v2geolassets_assetitem" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <editform tolerant="1"></editform>
@@ -368,8 +368,8 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField showLabel="1" name="geomquality" index="3"/>
-    <attributeEditorField showLabel="1" name="assetitem_lg_geolssts_v2geolassets_assetitem" index="5"/>
+    <attributeEditorField name="geomquality" index="3" showLabel="1"/>
+    <attributeEditorField name="assetitem_lg_geolssts_v2geolassets_assetitem" index="5" showLabel="1"/>
   </attributeEditorForm>
   <editable>
     <field name="T_Id" editable="1"/>
@@ -380,12 +380,12 @@ def my_form_open(dialog, layer, feature):
     <field name="geomquality" editable="1"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="T_Id"/>
-    <field labelOnTop="0" name="T_Ili_Tid"/>
-    <field labelOnTop="0" name="T_basket"/>
-    <field labelOnTop="0" name="assetitem_assetitem"/>
-    <field labelOnTop="0" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
-    <field labelOnTop="0" name="geomquality"/>
+    <field name="T_Id" labelOnTop="0"/>
+    <field name="T_Ili_Tid" labelOnTop="0"/>
+    <field name="T_basket" labelOnTop="0"/>
+    <field name="assetitem_assetitem" labelOnTop="0"/>
+    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" labelOnTop="0"/>
+    <field name="geomquality" labelOnTop="0"/>
   </labelOnTop>
   <reuseLastValue>
     <field reuseLastValue="0" name="T_Id"/>

--- a/lg_geolassets_v2/layerstyle/studytrace.qml
+++ b/lg_geolassets_v2/layerstyle/studytrace.qml
@@ -1,431 +1,431 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="LayerConfiguration|Symbology|Fields|Forms|CustomProperties" readOnly="0" version="3.24.3-Tisler">
+<qgis readOnly="0" version="3.22.11-Białowieża" styleCategories="LayerConfiguration|Symbology|Fields|Forms|CustomProperties">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
     <Private>0</Private>
   </flags>
-  <renderer-v2 type="RuleRenderer" referencescale="-1" symbollevels="0" enableorderby="0" forceraster="0">
+  <renderer-v2 forceraster="0" type="RuleRenderer" enableorderby="0" referencescale="-1" symbollevels="0">
     <rules key="{ab1280f2-2679-4bf3-983c-a64ae95ed90b}">
-      <rule label="Public" symbol="0" filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{92efec54-14aa-4a51-9243-3175cbfc427f}"/>
-      <rule label="Internal" symbol="1" filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " key="{92efec54-14aa-4a51-9243-3175cbfc427f}"/>
-      <rule label="Not Available" symbol="2" filter="ELSE" key="{f17db51f-9ff4-4de5-8de1-f28d49da7f9f}"/>
+      <rule filter="ELSE" symbol="0" label="Not Available" key="{f17db51f-9ff4-4de5-8de1-f28d49da7f9f}"/>
+      <rule filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " symbol="1" label="Internal" key="{3b381cd0-ec36-4b75-bf8b-3938a400fd0a}"/>
+      <rule filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" symbol="2" label="Public" key="{215f31f7-d1f8-4e65-bc9b-06fc41d91e04}"/>
     </rules>
     <symbols>
-      <symbol name="0" type="line" clip_to_extent="1" force_rhr="0" alpha="1">
+      <symbol force_rhr="0" alpha="1" type="line" clip_to_extent="1" name="0">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+        <layer enabled="1" pass="0" class="SimpleLine" locked="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0"/>
-            <Option name="capstyle" type="QString" value="round"/>
-            <Option name="customdash" type="QString" value="5;2"/>
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="customdash_unit" type="QString" value="MM"/>
-            <Option name="dash_pattern_offset" type="QString" value="0"/>
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-            <Option name="draw_inside_polygon" type="QString" value="0"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="line_color" type="QString" value="0,0,0,128"/>
-            <Option name="line_style" type="QString" value="solid"/>
-            <Option name="line_width" type="QString" value="1.66"/>
-            <Option name="line_width_unit" type="QString" value="MM"/>
-            <Option name="offset" type="QString" value="0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="ring_filter" type="QString" value="0"/>
-            <Option name="trim_distance_end" type="QString" value="0"/>
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-            <Option name="trim_distance_start" type="QString" value="0"/>
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-            <Option name="use_custom_dash" type="QString" value="0"/>
-            <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="round" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0,0,128" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="1.66" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
           </Option>
-          <prop k="align_dash_pattern" v="0"/>
-          <prop k="capstyle" v="round"/>
-          <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="dash_pattern_offset" v="0"/>
-          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="dash_pattern_offset_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="0,0,0,128"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="1.66"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="trim_distance_end" v="0"/>
-          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="trim_distance_end_unit" v="MM"/>
-          <prop k="trim_distance_start" v="0"/>
-          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="trim_distance_start_unit" v="MM"/>
-          <prop k="tweak_dash_pattern_on_corners" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop v="0" k="align_dash_pattern"/>
+          <prop v="round" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="dash_pattern_offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+          <prop v="MM" k="dash_pattern_offset_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0,0,128" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="1.66" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="trim_distance_end"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_end_unit"/>
+          <prop v="0" k="trim_distance_start"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_start_unit"/>
+          <prop v="0" k="tweak_dash_pattern_on_corners"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+        <layer enabled="1" pass="0" class="SimpleLine" locked="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0"/>
-            <Option name="capstyle" type="QString" value="round"/>
-            <Option name="customdash" type="QString" value="5;2"/>
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="customdash_unit" type="QString" value="MM"/>
-            <Option name="dash_pattern_offset" type="QString" value="0"/>
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-            <Option name="draw_inside_polygon" type="QString" value="0"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="line_color" type="QString" value="218,253,216,255"/>
-            <Option name="line_style" type="QString" value="solid"/>
-            <Option name="line_width" type="QString" value="0.46"/>
-            <Option name="line_width_unit" type="QString" value="MM"/>
-            <Option name="offset" type="QString" value="0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="ring_filter" type="QString" value="0"/>
-            <Option name="trim_distance_end" type="QString" value="0"/>
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-            <Option name="trim_distance_start" type="QString" value="0"/>
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-            <Option name="use_custom_dash" type="QString" value="0"/>
-            <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="round" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="246,71,137,255" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="0.46" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
           </Option>
-          <prop k="align_dash_pattern" v="0"/>
-          <prop k="capstyle" v="round"/>
-          <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="dash_pattern_offset" v="0"/>
-          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="dash_pattern_offset_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="218,253,216,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.46"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="trim_distance_end" v="0"/>
-          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="trim_distance_end_unit" v="MM"/>
-          <prop k="trim_distance_start" v="0"/>
-          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="trim_distance_start_unit" v="MM"/>
-          <prop k="tweak_dash_pattern_on_corners" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop v="0" k="align_dash_pattern"/>
+          <prop v="round" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="dash_pattern_offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+          <prop v="MM" k="dash_pattern_offset_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="246,71,137,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="0.46" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="trim_distance_end"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_end_unit"/>
+          <prop v="0" k="trim_distance_start"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_start_unit"/>
+          <prop v="0" k="tweak_dash_pattern_on_corners"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="1" type="line" clip_to_extent="1" force_rhr="0" alpha="1">
+      <symbol force_rhr="0" alpha="1" type="line" clip_to_extent="1" name="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+        <layer enabled="1" pass="0" class="SimpleLine" locked="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0"/>
-            <Option name="capstyle" type="QString" value="round"/>
-            <Option name="customdash" type="QString" value="5;2"/>
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="customdash_unit" type="QString" value="MM"/>
-            <Option name="dash_pattern_offset" type="QString" value="0"/>
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-            <Option name="draw_inside_polygon" type="QString" value="0"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="line_color" type="QString" value="0,0,0,128"/>
-            <Option name="line_style" type="QString" value="solid"/>
-            <Option name="line_width" type="QString" value="1.66"/>
-            <Option name="line_width_unit" type="QString" value="MM"/>
-            <Option name="offset" type="QString" value="0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="ring_filter" type="QString" value="0"/>
-            <Option name="trim_distance_end" type="QString" value="0"/>
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-            <Option name="trim_distance_start" type="QString" value="0"/>
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-            <Option name="use_custom_dash" type="QString" value="0"/>
-            <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="round" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0,0,128" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="1.66" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
           </Option>
-          <prop k="align_dash_pattern" v="0"/>
-          <prop k="capstyle" v="round"/>
-          <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="dash_pattern_offset" v="0"/>
-          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="dash_pattern_offset_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="0,0,0,128"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="1.66"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="trim_distance_end" v="0"/>
-          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="trim_distance_end_unit" v="MM"/>
-          <prop k="trim_distance_start" v="0"/>
-          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="trim_distance_start_unit" v="MM"/>
-          <prop k="tweak_dash_pattern_on_corners" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop v="0" k="align_dash_pattern"/>
+          <prop v="round" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="dash_pattern_offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+          <prop v="MM" k="dash_pattern_offset_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0,0,128" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="1.66" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="trim_distance_end"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_end_unit"/>
+          <prop v="0" k="trim_distance_start"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_start_unit"/>
+          <prop v="0" k="tweak_dash_pattern_on_corners"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+        <layer enabled="1" pass="0" class="SimpleLine" locked="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0"/>
-            <Option name="capstyle" type="QString" value="round"/>
-            <Option name="customdash" type="QString" value="5;2"/>
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="customdash_unit" type="QString" value="MM"/>
-            <Option name="dash_pattern_offset" type="QString" value="0"/>
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-            <Option name="draw_inside_polygon" type="QString" value="0"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="line_color" type="QString" value="254,209,147,255"/>
-            <Option name="line_style" type="QString" value="solid"/>
-            <Option name="line_width" type="QString" value="0.46"/>
-            <Option name="line_width_unit" type="QString" value="MM"/>
-            <Option name="offset" type="QString" value="0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="ring_filter" type="QString" value="0"/>
-            <Option name="trim_distance_end" type="QString" value="0"/>
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-            <Option name="trim_distance_start" type="QString" value="0"/>
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-            <Option name="use_custom_dash" type="QString" value="0"/>
-            <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="round" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="254,209,147,255" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="0.46" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
           </Option>
-          <prop k="align_dash_pattern" v="0"/>
-          <prop k="capstyle" v="round"/>
-          <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="dash_pattern_offset" v="0"/>
-          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="dash_pattern_offset_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="254,209,147,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.46"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="trim_distance_end" v="0"/>
-          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="trim_distance_end_unit" v="MM"/>
-          <prop k="trim_distance_start" v="0"/>
-          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="trim_distance_start_unit" v="MM"/>
-          <prop k="tweak_dash_pattern_on_corners" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop v="0" k="align_dash_pattern"/>
+          <prop v="round" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="dash_pattern_offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+          <prop v="MM" k="dash_pattern_offset_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="254,209,147,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="0.46" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="trim_distance_end"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_end_unit"/>
+          <prop v="0" k="trim_distance_start"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_start_unit"/>
+          <prop v="0" k="tweak_dash_pattern_on_corners"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol name="2" type="line" clip_to_extent="1" force_rhr="0" alpha="1">
+      <symbol force_rhr="0" alpha="1" type="line" clip_to_extent="1" name="2">
         <data_defined_properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option value="" type="QString" name="name"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option value="collection" type="QString" name="type"/>
           </Option>
         </data_defined_properties>
-        <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+        <layer enabled="1" pass="0" class="SimpleLine" locked="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0"/>
-            <Option name="capstyle" type="QString" value="round"/>
-            <Option name="customdash" type="QString" value="5;2"/>
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="customdash_unit" type="QString" value="MM"/>
-            <Option name="dash_pattern_offset" type="QString" value="0"/>
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-            <Option name="draw_inside_polygon" type="QString" value="0"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="line_color" type="QString" value="0,0,0,128"/>
-            <Option name="line_style" type="QString" value="solid"/>
-            <Option name="line_width" type="QString" value="1.66"/>
-            <Option name="line_width_unit" type="QString" value="MM"/>
-            <Option name="offset" type="QString" value="0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="ring_filter" type="QString" value="0"/>
-            <Option name="trim_distance_end" type="QString" value="0"/>
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-            <Option name="trim_distance_start" type="QString" value="0"/>
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-            <Option name="use_custom_dash" type="QString" value="0"/>
-            <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="round" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="0,0,0,128" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="1.66" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
           </Option>
-          <prop k="align_dash_pattern" v="0"/>
-          <prop k="capstyle" v="round"/>
-          <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="dash_pattern_offset" v="0"/>
-          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="dash_pattern_offset_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="0,0,0,128"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="1.66"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="trim_distance_end" v="0"/>
-          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="trim_distance_end_unit" v="MM"/>
-          <prop k="trim_distance_start" v="0"/>
-          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="trim_distance_start_unit" v="MM"/>
-          <prop k="tweak_dash_pattern_on_corners" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop v="0" k="align_dash_pattern"/>
+          <prop v="round" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="dash_pattern_offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+          <prop v="MM" k="dash_pattern_offset_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="0,0,0,128" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="1.66" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="trim_distance_end"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_end_unit"/>
+          <prop v="0" k="trim_distance_start"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_start_unit"/>
+          <prop v="0" k="tweak_dash_pattern_on_corners"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer class="SimpleLine" locked="0" pass="0" enabled="1">
+        <layer enabled="1" pass="0" class="SimpleLine" locked="0">
           <Option type="Map">
-            <Option name="align_dash_pattern" type="QString" value="0"/>
-            <Option name="capstyle" type="QString" value="round"/>
-            <Option name="customdash" type="QString" value="5;2"/>
-            <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="customdash_unit" type="QString" value="MM"/>
-            <Option name="dash_pattern_offset" type="QString" value="0"/>
-            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-            <Option name="draw_inside_polygon" type="QString" value="0"/>
-            <Option name="joinstyle" type="QString" value="bevel"/>
-            <Option name="line_color" type="QString" value="246,71,137,255"/>
-            <Option name="line_style" type="QString" value="solid"/>
-            <Option name="line_width" type="QString" value="0.46"/>
-            <Option name="line_width_unit" type="QString" value="MM"/>
-            <Option name="offset" type="QString" value="0"/>
-            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="offset_unit" type="QString" value="MM"/>
-            <Option name="ring_filter" type="QString" value="0"/>
-            <Option name="trim_distance_end" type="QString" value="0"/>
-            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-            <Option name="trim_distance_start" type="QString" value="0"/>
-            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-            <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-            <Option name="use_custom_dash" type="QString" value="0"/>
-            <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option value="0" type="QString" name="align_dash_pattern"/>
+            <Option value="round" type="QString" name="capstyle"/>
+            <Option value="5;2" type="QString" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
+            <Option value="MM" type="QString" name="customdash_unit"/>
+            <Option value="0" type="QString" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
+            <Option value="0" type="QString" name="draw_inside_polygon"/>
+            <Option value="bevel" type="QString" name="joinstyle"/>
+            <Option value="218,253,216,255" type="QString" name="line_color"/>
+            <Option value="solid" type="QString" name="line_style"/>
+            <Option value="0.46" type="QString" name="line_width"/>
+            <Option value="MM" type="QString" name="line_width_unit"/>
+            <Option value="0" type="QString" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+            <Option value="MM" type="QString" name="offset_unit"/>
+            <Option value="0" type="QString" name="ring_filter"/>
+            <Option value="0" type="QString" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
+            <Option value="0" type="QString" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
+            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" type="QString" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
           </Option>
-          <prop k="align_dash_pattern" v="0"/>
-          <prop k="capstyle" v="round"/>
-          <prop k="customdash" v="5;2"/>
-          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="customdash_unit" v="MM"/>
-          <prop k="dash_pattern_offset" v="0"/>
-          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="dash_pattern_offset_unit" v="MM"/>
-          <prop k="draw_inside_polygon" v="0"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="line_color" v="246,71,137,255"/>
-          <prop k="line_style" v="solid"/>
-          <prop k="line_width" v="0.46"/>
-          <prop k="line_width_unit" v="MM"/>
-          <prop k="offset" v="0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="ring_filter" v="0"/>
-          <prop k="trim_distance_end" v="0"/>
-          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="trim_distance_end_unit" v="MM"/>
-          <prop k="trim_distance_start" v="0"/>
-          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="trim_distance_start_unit" v="MM"/>
-          <prop k="tweak_dash_pattern_on_corners" v="0"/>
-          <prop k="use_custom_dash" v="0"/>
-          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop v="0" k="align_dash_pattern"/>
+          <prop v="round" k="capstyle"/>
+          <prop v="5;2" k="customdash"/>
+          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
+          <prop v="MM" k="customdash_unit"/>
+          <prop v="0" k="dash_pattern_offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
+          <prop v="MM" k="dash_pattern_offset_unit"/>
+          <prop v="0" k="draw_inside_polygon"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="218,253,216,255" k="line_color"/>
+          <prop v="solid" k="line_style"/>
+          <prop v="0.46" k="line_width"/>
+          <prop v="MM" k="line_width_unit"/>
+          <prop v="0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MM" k="offset_unit"/>
+          <prop v="0" k="ring_filter"/>
+          <prop v="0" k="trim_distance_end"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_end_unit"/>
+          <prop v="0" k="trim_distance_start"/>
+          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
+          <prop v="MM" k="trim_distance_start_unit"/>
+          <prop v="0" k="tweak_dash_pattern_on_corners"/>
+          <prop v="0" k="use_custom_dash"/>
+          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option name="name" type="QString" value=""/>
+              <Option value="" type="QString" name="name"/>
               <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
+              <Option value="collection" type="QString" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -434,151 +434,151 @@
   </renderer-v2>
   <customproperties>
     <Option type="Map">
-      <Option name="QFieldSync/action" type="QString" value="copy"/>
-      <Option name="QFieldSync/cloud_action" type="QString" value="offline"/>
-      <Option name="QFieldSync/photo_naming" type="QString" value="{}"/>
-      <Option name="dualview/previewExpressions" type="List">
-        <Option type="QString" value="if(length(geom_to_wkt( $geometry ))>22,substr(geom_to_wkt( $geometry ),0,23)||'...',geom_to_wkt( $geometry ))"/>
+      <Option value="copy" type="QString" name="QFieldSync/action"/>
+      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
+      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
+      <Option type="List" name="dualview/previewExpressions">
+        <Option value="if(length(geom_to_wkt( $geometry ))>22,substr(geom_to_wkt( $geometry ),0,23)||'...',geom_to_wkt( $geometry ))" type="QString"/>
       </Option>
-      <Option name="embeddedWidgets/count" type="int" value="0"/>
-      <Option name="variableNames" type="StringList">
-        <Option type="QString" value="interlis_topic"/>
+      <Option value="0" type="int" name="embeddedWidgets/count"/>
+      <Option type="StringList" name="variableNames">
+        <Option value="interlis_topic" type="QString"/>
       </Option>
-      <Option name="variableValues" type="StringList">
-        <Option type="QString" value="LG_GeolAssets_V2.GeolAssets"/>
+      <Option type="StringList" name="variableValues">
+        <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
       </Option>
     </Option>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <fieldConfiguration>
-    <field name="T_Id" configurationFlags="None">
+    <field configurationFlags="None" name="T_Id">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="T_basket" configurationFlags="None">
+    <field configurationFlags="None" name="T_basket">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="ChainFilters" type="bool" value="false"/>
-            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; ='LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
-            <Option name="FilterFields" type="invalid"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="true"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c"/>
-            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="studytrace_T_basket_T_ILI2DB_BASKET_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="false"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="ChainFilters"/>
+            <Option value="&quot;topic&quot; ='LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString" name="FilterExpression"/>
+            <Option type="invalid" name="FilterFields"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="true" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" type="QString" name="ReferencedLayerId"/>
+            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="studytrace_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="false" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="T_Ili_Tid" configurationFlags="None">
+    <field configurationFlags="None" name="T_Ili_Tid">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option name="IsMultiline" type="bool" value="false"/>
-            <Option name="UseHtml" type="bool" value="false"/>
+            <Option value="false" type="bool" name="IsMultiline"/>
+            <Option value="false" type="bool" name="UseHtml"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="geomquality" configurationFlags="None">
+    <field configurationFlags="None" name="geomquality">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="true"/>
-            <Option name="ChainFilters" type="bool" value="false"/>
-            <Option name="FilterExpression" type="QString" value=""/>
-            <Option name="FilterFields" type="invalid"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="true"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8"/>
-            <Option name="ReferencedLayerName" type="QString" value="GeomQualityItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="studytrace_geomquality_geomqualityitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="false"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="true" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="ChainFilters"/>
+            <Option value="" type="QString" name="FilterExpression"/>
+            <Option type="invalid" name="FilterFields"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="true" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8" type="QString" name="ReferencedLayerId"/>
+            <Option value="GeomQualityItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="studytrace_geomquality_geomqualityitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="false" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="assetitem_assetitem" configurationFlags="None">
+    <field configurationFlags="None" name="assetitem_assetitem">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="true"/>
-            <Option name="AllowNULL" type="bool" value="true"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="true"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e"/>
-            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="studytrace_assetitem_assetitem_assetitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="false"/>
+            <Option value="true" type="bool" name="AllowAddFeatures"/>
+            <Option value="true" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="true" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e" type="QString" name="ReferencedLayerId"/>
+            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="studytrace_assetitem_assetitem_assetitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="false" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" configurationFlags="None">
+    <field configurationFlags="None" name="assetitem_lg_geolssts_v2geolassets_assetitem">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="true"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="true"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
-            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="studytrace_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="true" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="true" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d" type="QString" name="ReferencedLayerId"/>
+            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="studytrace_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="T_Id"/>
-    <alias name="" index="1" field="T_basket"/>
-    <alias name="" index="2" field="T_Ili_Tid"/>
-    <alias name="Qualität" index="3" field="geomquality"/>
-    <alias name="AssetItem" index="4" field="assetitem_assetitem"/>
-    <alias name="AssetItem" index="5" field="assetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <alias field="T_Id" index="0" name=""/>
+    <alias field="T_basket" index="1" name=""/>
+    <alias field="T_Ili_Tid" index="2" name=""/>
+    <alias field="geomquality" index="3" name="Qualität"/>
+    <alias field="assetitem_assetitem" index="4" name="AssetItem"/>
+    <alias field="assetitem_lg_geolssts_v2geolassets_assetitem" index="5" name="AssetItem"/>
   </aliases>
   <defaults>
-    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
-    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
-    <default applyOnUpdate="0" field="T_Ili_Tid" expression="substr(uuid(), 2, 36)"/>
-    <default applyOnUpdate="0" field="geomquality" expression=""/>
-    <default applyOnUpdate="0" field="assetitem_assetitem" expression=""/>
-    <default applyOnUpdate="0" field="assetitem_lg_geolssts_v2geolassets_assetitem" expression=""/>
+    <default expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" field="T_Id" applyOnUpdate="0"/>
+    <default expression="@default_basket_lg_geolassets_v2_geolassets" field="T_basket" applyOnUpdate="0"/>
+    <default expression="substr(uuid(), 2, 36)" field="T_Ili_Tid" applyOnUpdate="0"/>
+    <default expression="" field="geomquality" applyOnUpdate="0"/>
+    <default expression="" field="assetitem_assetitem" applyOnUpdate="0"/>
+    <default expression="" field="assetitem_lg_geolssts_v2geolassets_assetitem" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="1" constraints="2" field="T_Ili_Tid" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="geomquality" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="assetitem_assetitem" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" field="assetitem_lg_geolssts_v2geolassets_assetitem" notnull_strength="1" exp_strength="0"/>
+    <constraint field="T_Id" exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3"/>
+    <constraint field="T_basket" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint field="T_Ili_Tid" exp_strength="0" unique_strength="1" notnull_strength="0" constraints="2"/>
+    <constraint field="geomquality" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="assetitem_assetitem" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="assetitem_lg_geolssts_v2geolassets_assetitem" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="T_Id" desc=""/>
@@ -611,24 +611,24 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField name="geomquality" index="3" showLabel="1"/>
-    <attributeEditorField name="assetitem_lg_geolssts_v2geolassets_assetitem" index="5" showLabel="1"/>
+    <attributeEditorField index="3" showLabel="1" name="geomquality"/>
+    <attributeEditorField index="5" showLabel="1" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
   </attributeEditorForm>
   <editable>
-    <field name="T_Id" editable="1"/>
-    <field name="T_Ili_Tid" editable="1"/>
-    <field name="T_basket" editable="1"/>
-    <field name="assetitem_assetitem" editable="1"/>
-    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" editable="0"/>
-    <field name="geomquality" editable="1"/>
+    <field editable="1" name="T_Id"/>
+    <field editable="1" name="T_Ili_Tid"/>
+    <field editable="1" name="T_basket"/>
+    <field editable="1" name="assetitem_assetitem"/>
+    <field editable="0" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <field editable="1" name="geomquality"/>
   </editable>
   <labelOnTop>
-    <field name="T_Id" labelOnTop="0"/>
-    <field name="T_Ili_Tid" labelOnTop="0"/>
-    <field name="T_basket" labelOnTop="0"/>
-    <field name="assetitem_assetitem" labelOnTop="0"/>
-    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" labelOnTop="0"/>
-    <field name="geomquality" labelOnTop="0"/>
+    <field labelOnTop="0" name="T_Id"/>
+    <field labelOnTop="0" name="T_Ili_Tid"/>
+    <field labelOnTop="0" name="T_basket"/>
+    <field labelOnTop="0" name="assetitem_assetitem"/>
+    <field labelOnTop="0" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <field labelOnTop="0" name="geomquality"/>
   </labelOnTop>
   <reuseLastValue>
     <field reuseLastValue="0" name="T_Id"/>

--- a/lg_geolassets_v2/layerstyle/studytrace.qml
+++ b/lg_geolassets_v2/layerstyle/studytrace.qml
@@ -1,431 +1,431 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="LayerConfiguration|Symbology|Fields|Forms|CustomProperties" readOnly="0" version="3.25.0-Master">
+<qgis styleCategories="LayerConfiguration|Symbology|Fields|Forms|CustomProperties" readOnly="0" version="3.24.3-Tisler">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
     <Searchable>1</Searchable>
     <Private>0</Private>
   </flags>
-  <renderer-v2 referencescale="-1" type="RuleRenderer" symbollevels="0" forceraster="0" enableorderby="0">
+  <renderer-v2 type="RuleRenderer" referencescale="-1" symbollevels="0" enableorderby="0" forceraster="0">
     <rules key="{ab1280f2-2679-4bf3-983c-a64ae95ed90b}">
-      <rule filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" symbol="0" key="{92efec54-14aa-4a51-9243-3175cbfc427f}" label="Public"/>
-      <rule filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " symbol="1" key="{92efec54-14aa-4a51-9243-3175cbfc427f}" label="Internal"/>
-      <rule filter="ELSE" symbol="2" key="{f17db51f-9ff4-4de5-8de1-f28d49da7f9f}" label="Not Available"/>
+      <rule label="Public" symbol="0" filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{92efec54-14aa-4a51-9243-3175cbfc427f}"/>
+      <rule label="Internal" symbol="1" filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " key="{92efec54-14aa-4a51-9243-3175cbfc427f}"/>
+      <rule label="Not Available" symbol="2" filter="ELSE" key="{f17db51f-9ff4-4de5-8de1-f28d49da7f9f}"/>
     </rules>
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" force_rhr="0" is_animated="0" type="line" name="0" frame_rate="10">
+      <symbol name="0" type="line" clip_to_extent="1" force_rhr="0" alpha="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option name="name" type="QString" value=""/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
         </data_defined_properties>
-        <layer pass="0" class="SimpleLine" enabled="1" locked="0">
+        <layer class="SimpleLine" locked="0" pass="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="align_dash_pattern"/>
-            <Option value="round" type="QString" name="capstyle"/>
-            <Option value="5;2" type="QString" name="customdash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
-            <Option value="MM" type="QString" name="customdash_unit"/>
-            <Option value="0" type="QString" name="dash_pattern_offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
-            <Option value="0" type="QString" name="draw_inside_polygon"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0,0,128" type="QString" name="line_color"/>
-            <Option value="solid" type="QString" name="line_style"/>
-            <Option value="1.66" type="QString" name="line_width"/>
-            <Option value="MM" type="QString" name="line_width_unit"/>
-            <Option value="0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0" type="QString" name="ring_filter"/>
-            <Option value="0" type="QString" name="trim_distance_end"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
-            <Option value="0" type="QString" name="trim_distance_start"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
-            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
-            <Option value="0" type="QString" name="use_custom_dash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+            <Option name="align_dash_pattern" type="QString" value="0"/>
+            <Option name="capstyle" type="QString" value="round"/>
+            <Option name="customdash" type="QString" value="5;2"/>
+            <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="customdash_unit" type="QString" value="MM"/>
+            <Option name="dash_pattern_offset" type="QString" value="0"/>
+            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+            <Option name="draw_inside_polygon" type="QString" value="0"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="line_color" type="QString" value="0,0,0,128"/>
+            <Option name="line_style" type="QString" value="solid"/>
+            <Option name="line_width" type="QString" value="1.66"/>
+            <Option name="line_width_unit" type="QString" value="MM"/>
+            <Option name="offset" type="QString" value="0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="ring_filter" type="QString" value="0"/>
+            <Option name="trim_distance_end" type="QString" value="0"/>
+            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+            <Option name="trim_distance_start" type="QString" value="0"/>
+            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+            <Option name="use_custom_dash" type="QString" value="0"/>
+            <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
           </Option>
-          <prop v="0" k="align_dash_pattern"/>
-          <prop v="round" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="dash_pattern_offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-          <prop v="MM" k="dash_pattern_offset_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0,0,128" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="1.66" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="trim_distance_end"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_end_unit"/>
-          <prop v="0" k="trim_distance_start"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_start_unit"/>
-          <prop v="0" k="tweak_dash_pattern_on_corners"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="round"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="0,0,0,128"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="1.66"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer pass="0" class="SimpleLine" enabled="1" locked="0">
+        <layer class="SimpleLine" locked="0" pass="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="align_dash_pattern"/>
-            <Option value="round" type="QString" name="capstyle"/>
-            <Option value="5;2" type="QString" name="customdash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
-            <Option value="MM" type="QString" name="customdash_unit"/>
-            <Option value="0" type="QString" name="dash_pattern_offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
-            <Option value="0" type="QString" name="draw_inside_polygon"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="218,253,216,255" type="QString" name="line_color"/>
-            <Option value="solid" type="QString" name="line_style"/>
-            <Option value="0.46" type="QString" name="line_width"/>
-            <Option value="MM" type="QString" name="line_width_unit"/>
-            <Option value="0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0" type="QString" name="ring_filter"/>
-            <Option value="0" type="QString" name="trim_distance_end"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
-            <Option value="0" type="QString" name="trim_distance_start"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
-            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
-            <Option value="0" type="QString" name="use_custom_dash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+            <Option name="align_dash_pattern" type="QString" value="0"/>
+            <Option name="capstyle" type="QString" value="round"/>
+            <Option name="customdash" type="QString" value="5;2"/>
+            <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="customdash_unit" type="QString" value="MM"/>
+            <Option name="dash_pattern_offset" type="QString" value="0"/>
+            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+            <Option name="draw_inside_polygon" type="QString" value="0"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="line_color" type="QString" value="218,253,216,255"/>
+            <Option name="line_style" type="QString" value="solid"/>
+            <Option name="line_width" type="QString" value="0.46"/>
+            <Option name="line_width_unit" type="QString" value="MM"/>
+            <Option name="offset" type="QString" value="0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="ring_filter" type="QString" value="0"/>
+            <Option name="trim_distance_end" type="QString" value="0"/>
+            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+            <Option name="trim_distance_start" type="QString" value="0"/>
+            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+            <Option name="use_custom_dash" type="QString" value="0"/>
+            <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
           </Option>
-          <prop v="0" k="align_dash_pattern"/>
-          <prop v="round" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="dash_pattern_offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-          <prop v="MM" k="dash_pattern_offset_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="218,253,216,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.46" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="trim_distance_end"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_end_unit"/>
-          <prop v="0" k="trim_distance_start"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_start_unit"/>
-          <prop v="0" k="tweak_dash_pattern_on_corners"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="round"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="218,253,216,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.46"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" force_rhr="0" is_animated="0" type="line" name="1" frame_rate="10">
+      <symbol name="1" type="line" clip_to_extent="1" force_rhr="0" alpha="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option name="name" type="QString" value=""/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
         </data_defined_properties>
-        <layer pass="0" class="SimpleLine" enabled="1" locked="0">
+        <layer class="SimpleLine" locked="0" pass="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="align_dash_pattern"/>
-            <Option value="round" type="QString" name="capstyle"/>
-            <Option value="5;2" type="QString" name="customdash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
-            <Option value="MM" type="QString" name="customdash_unit"/>
-            <Option value="0" type="QString" name="dash_pattern_offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
-            <Option value="0" type="QString" name="draw_inside_polygon"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0,0,128" type="QString" name="line_color"/>
-            <Option value="solid" type="QString" name="line_style"/>
-            <Option value="1.66" type="QString" name="line_width"/>
-            <Option value="MM" type="QString" name="line_width_unit"/>
-            <Option value="0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0" type="QString" name="ring_filter"/>
-            <Option value="0" type="QString" name="trim_distance_end"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
-            <Option value="0" type="QString" name="trim_distance_start"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
-            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
-            <Option value="0" type="QString" name="use_custom_dash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+            <Option name="align_dash_pattern" type="QString" value="0"/>
+            <Option name="capstyle" type="QString" value="round"/>
+            <Option name="customdash" type="QString" value="5;2"/>
+            <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="customdash_unit" type="QString" value="MM"/>
+            <Option name="dash_pattern_offset" type="QString" value="0"/>
+            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+            <Option name="draw_inside_polygon" type="QString" value="0"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="line_color" type="QString" value="0,0,0,128"/>
+            <Option name="line_style" type="QString" value="solid"/>
+            <Option name="line_width" type="QString" value="1.66"/>
+            <Option name="line_width_unit" type="QString" value="MM"/>
+            <Option name="offset" type="QString" value="0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="ring_filter" type="QString" value="0"/>
+            <Option name="trim_distance_end" type="QString" value="0"/>
+            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+            <Option name="trim_distance_start" type="QString" value="0"/>
+            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+            <Option name="use_custom_dash" type="QString" value="0"/>
+            <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
           </Option>
-          <prop v="0" k="align_dash_pattern"/>
-          <prop v="round" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="dash_pattern_offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-          <prop v="MM" k="dash_pattern_offset_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0,0,128" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="1.66" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="trim_distance_end"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_end_unit"/>
-          <prop v="0" k="trim_distance_start"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_start_unit"/>
-          <prop v="0" k="tweak_dash_pattern_on_corners"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="round"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="0,0,0,128"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="1.66"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer pass="0" class="SimpleLine" enabled="1" locked="0">
+        <layer class="SimpleLine" locked="0" pass="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="align_dash_pattern"/>
-            <Option value="round" type="QString" name="capstyle"/>
-            <Option value="5;2" type="QString" name="customdash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
-            <Option value="MM" type="QString" name="customdash_unit"/>
-            <Option value="0" type="QString" name="dash_pattern_offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
-            <Option value="0" type="QString" name="draw_inside_polygon"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="254,209,147,255" type="QString" name="line_color"/>
-            <Option value="solid" type="QString" name="line_style"/>
-            <Option value="0.46" type="QString" name="line_width"/>
-            <Option value="MM" type="QString" name="line_width_unit"/>
-            <Option value="0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0" type="QString" name="ring_filter"/>
-            <Option value="0" type="QString" name="trim_distance_end"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
-            <Option value="0" type="QString" name="trim_distance_start"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
-            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
-            <Option value="0" type="QString" name="use_custom_dash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+            <Option name="align_dash_pattern" type="QString" value="0"/>
+            <Option name="capstyle" type="QString" value="round"/>
+            <Option name="customdash" type="QString" value="5;2"/>
+            <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="customdash_unit" type="QString" value="MM"/>
+            <Option name="dash_pattern_offset" type="QString" value="0"/>
+            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+            <Option name="draw_inside_polygon" type="QString" value="0"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="line_color" type="QString" value="254,209,147,255"/>
+            <Option name="line_style" type="QString" value="solid"/>
+            <Option name="line_width" type="QString" value="0.46"/>
+            <Option name="line_width_unit" type="QString" value="MM"/>
+            <Option name="offset" type="QString" value="0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="ring_filter" type="QString" value="0"/>
+            <Option name="trim_distance_end" type="QString" value="0"/>
+            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+            <Option name="trim_distance_start" type="QString" value="0"/>
+            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+            <Option name="use_custom_dash" type="QString" value="0"/>
+            <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
           </Option>
-          <prop v="0" k="align_dash_pattern"/>
-          <prop v="round" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="dash_pattern_offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-          <prop v="MM" k="dash_pattern_offset_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="254,209,147,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.46" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="trim_distance_end"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_end_unit"/>
-          <prop v="0" k="trim_distance_start"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_start_unit"/>
-          <prop v="0" k="tweak_dash_pattern_on_corners"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="round"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="254,209,147,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.46"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol alpha="1" clip_to_extent="1" force_rhr="0" is_animated="0" type="line" name="2" frame_rate="10">
+      <symbol name="2" type="line" clip_to_extent="1" force_rhr="0" alpha="1">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option name="name" type="QString" value=""/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
         </data_defined_properties>
-        <layer pass="0" class="SimpleLine" enabled="1" locked="0">
+        <layer class="SimpleLine" locked="0" pass="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="align_dash_pattern"/>
-            <Option value="round" type="QString" name="capstyle"/>
-            <Option value="5;2" type="QString" name="customdash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
-            <Option value="MM" type="QString" name="customdash_unit"/>
-            <Option value="0" type="QString" name="dash_pattern_offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
-            <Option value="0" type="QString" name="draw_inside_polygon"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0,0,128" type="QString" name="line_color"/>
-            <Option value="solid" type="QString" name="line_style"/>
-            <Option value="1.66" type="QString" name="line_width"/>
-            <Option value="MM" type="QString" name="line_width_unit"/>
-            <Option value="0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0" type="QString" name="ring_filter"/>
-            <Option value="0" type="QString" name="trim_distance_end"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
-            <Option value="0" type="QString" name="trim_distance_start"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
-            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
-            <Option value="0" type="QString" name="use_custom_dash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+            <Option name="align_dash_pattern" type="QString" value="0"/>
+            <Option name="capstyle" type="QString" value="round"/>
+            <Option name="customdash" type="QString" value="5;2"/>
+            <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="customdash_unit" type="QString" value="MM"/>
+            <Option name="dash_pattern_offset" type="QString" value="0"/>
+            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+            <Option name="draw_inside_polygon" type="QString" value="0"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="line_color" type="QString" value="0,0,0,128"/>
+            <Option name="line_style" type="QString" value="solid"/>
+            <Option name="line_width" type="QString" value="1.66"/>
+            <Option name="line_width_unit" type="QString" value="MM"/>
+            <Option name="offset" type="QString" value="0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="ring_filter" type="QString" value="0"/>
+            <Option name="trim_distance_end" type="QString" value="0"/>
+            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+            <Option name="trim_distance_start" type="QString" value="0"/>
+            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+            <Option name="use_custom_dash" type="QString" value="0"/>
+            <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
           </Option>
-          <prop v="0" k="align_dash_pattern"/>
-          <prop v="round" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="dash_pattern_offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-          <prop v="MM" k="dash_pattern_offset_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0,0,128" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="1.66" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="trim_distance_end"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_end_unit"/>
-          <prop v="0" k="trim_distance_start"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_start_unit"/>
-          <prop v="0" k="tweak_dash_pattern_on_corners"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="round"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="0,0,0,128"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="1.66"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer pass="0" class="SimpleLine" enabled="1" locked="0">
+        <layer class="SimpleLine" locked="0" pass="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="align_dash_pattern"/>
-            <Option value="round" type="QString" name="capstyle"/>
-            <Option value="5;2" type="QString" name="customdash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
-            <Option value="MM" type="QString" name="customdash_unit"/>
-            <Option value="0" type="QString" name="dash_pattern_offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
-            <Option value="0" type="QString" name="draw_inside_polygon"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="246,71,137,255" type="QString" name="line_color"/>
-            <Option value="solid" type="QString" name="line_style"/>
-            <Option value="0.46" type="QString" name="line_width"/>
-            <Option value="MM" type="QString" name="line_width_unit"/>
-            <Option value="0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0" type="QString" name="ring_filter"/>
-            <Option value="0" type="QString" name="trim_distance_end"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
-            <Option value="0" type="QString" name="trim_distance_start"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
-            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
-            <Option value="0" type="QString" name="use_custom_dash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+            <Option name="align_dash_pattern" type="QString" value="0"/>
+            <Option name="capstyle" type="QString" value="round"/>
+            <Option name="customdash" type="QString" value="5;2"/>
+            <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="customdash_unit" type="QString" value="MM"/>
+            <Option name="dash_pattern_offset" type="QString" value="0"/>
+            <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
+            <Option name="draw_inside_polygon" type="QString" value="0"/>
+            <Option name="joinstyle" type="QString" value="bevel"/>
+            <Option name="line_color" type="QString" value="246,71,137,255"/>
+            <Option name="line_style" type="QString" value="solid"/>
+            <Option name="line_width" type="QString" value="0.46"/>
+            <Option name="line_width_unit" type="QString" value="MM"/>
+            <Option name="offset" type="QString" value="0"/>
+            <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_unit" type="QString" value="MM"/>
+            <Option name="ring_filter" type="QString" value="0"/>
+            <Option name="trim_distance_end" type="QString" value="0"/>
+            <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="trim_distance_end_unit" type="QString" value="MM"/>
+            <Option name="trim_distance_start" type="QString" value="0"/>
+            <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="trim_distance_start_unit" type="QString" value="MM"/>
+            <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
+            <Option name="use_custom_dash" type="QString" value="0"/>
+            <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
           </Option>
-          <prop v="0" k="align_dash_pattern"/>
-          <prop v="round" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="dash_pattern_offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-          <prop v="MM" k="dash_pattern_offset_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="246,71,137,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.46" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="trim_distance_end"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_end_unit"/>
-          <prop v="0" k="trim_distance_start"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_start_unit"/>
-          <prop v="0" k="tweak_dash_pattern_on_corners"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="round"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="246,71,137,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.46"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option name="name" type="QString" value=""/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option name="type" type="QString" value="collection"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -434,159 +434,159 @@
   </renderer-v2>
   <customproperties>
     <Option type="Map">
-      <Option value="copy" type="QString" name="QFieldSync/action"/>
-      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
-      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
-      <Option type="List" name="dualview/previewExpressions">
-        <Option value="if(length(geom_to_wkt( $geometry ))>22,substr(geom_to_wkt( $geometry ),0,23)||'...',geom_to_wkt( $geometry ))" type="QString"/>
+      <Option name="QFieldSync/action" type="QString" value="copy"/>
+      <Option name="QFieldSync/cloud_action" type="QString" value="offline"/>
+      <Option name="QFieldSync/photo_naming" type="QString" value="{}"/>
+      <Option name="dualview/previewExpressions" type="List">
+        <Option type="QString" value="if(length(geom_to_wkt( $geometry ))>22,substr(geom_to_wkt( $geometry ),0,23)||'...',geom_to_wkt( $geometry ))"/>
       </Option>
-      <Option value="0" type="int" name="embeddedWidgets/count"/>
-      <Option type="StringList" name="variableNames">
-        <Option value="interlis_topic" type="QString"/>
+      <Option name="embeddedWidgets/count" type="int" value="0"/>
+      <Option name="variableNames" type="StringList">
+        <Option type="QString" value="interlis_topic"/>
       </Option>
-      <Option type="StringList" name="variableValues">
-        <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
+      <Option name="variableValues" type="StringList">
+        <Option type="QString" value="LG_GeolAssets_V2.GeolAssets"/>
       </Option>
     </Option>
   </customproperties>
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id">
+    <field name="T_Id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_basket">
+    <field name="T_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="false" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="&quot;topic&quot; ='LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" type="QString" name="ReferencedLayerId"/>
-            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studytrace_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="ChainFilters" type="bool" value="false"/>
+            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; ='LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c"/>
+            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="studytrace_T_basket_T_ILI2DB_BASKET_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_Ili_Tid">
+    <field name="T_Ili_Tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="geomquality">
+    <field name="geomquality" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8" type="QString" name="ReferencedLayerId"/>
-            <Option value="GeomQualityItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studytrace_geomquality_geomqualityitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="ChainFilters" type="bool" value="false"/>
+            <Option name="FilterExpression" type="QString" value=""/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8"/>
+            <Option name="ReferencedLayerName" type="QString" value="GeomQualityItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="studytrace_geomquality_geomqualityitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="assetitem_assetitem">
+    <field name="assetitem_assetitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="true" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e" type="QString" name="ReferencedLayerId"/>
-            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studytrace_assetitem_assetitem_assetitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="true"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="studytrace_assetitem_assetitem_assetitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="assetitem_lg_geolssts_v2geolassets_assetitem">
+    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_4/lg_geolAssets_v2_data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="AssetItem_655d7d08_f608_4aef_b23f_9bfc2ff514b1" type="QString" name="ReferencedLayerId"/>
-            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studytrace_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="studytrace_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="T_Id" index="0" name=""/>
-    <alias field="T_basket" index="1" name=""/>
-    <alias field="T_Ili_Tid" index="2" name=""/>
-    <alias field="geomquality" index="3" name="Qualität"/>
-    <alias field="assetitem_assetitem" index="4" name="AssetItem"/>
-    <alias field="assetitem_lg_geolssts_v2geolassets_assetitem" index="5" name="AssetItem"/>
+    <alias name="" index="0" field="T_Id"/>
+    <alias name="" index="1" field="T_basket"/>
+    <alias name="" index="2" field="T_Ili_Tid"/>
+    <alias name="Qualität" index="3" field="geomquality"/>
+    <alias name="AssetItem" index="4" field="assetitem_assetitem"/>
+    <alias name="AssetItem" index="5" field="assetitem_lg_geolssts_v2geolassets_assetitem"/>
   </aliases>
   <defaults>
-    <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
-    <default field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets" applyOnUpdate="0"/>
-    <default field="T_Ili_Tid" expression="substr(uuid(), 2, 36)" applyOnUpdate="0"/>
-    <default field="geomquality" expression="" applyOnUpdate="0"/>
-    <default field="assetitem_assetitem" expression="" applyOnUpdate="0"/>
-    <default field="assetitem_lg_geolssts_v2geolassets_assetitem" expression="" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
+    <default applyOnUpdate="0" field="T_basket" expression="@default_basket_lg_geolassets_v2_geolassets"/>
+    <default applyOnUpdate="0" field="T_Ili_Tid" expression="substr(uuid(), 2, 36)"/>
+    <default applyOnUpdate="0" field="geomquality" expression=""/>
+    <default applyOnUpdate="0" field="assetitem_assetitem" expression=""/>
+    <default applyOnUpdate="0" field="assetitem_lg_geolssts_v2geolassets_assetitem" expression=""/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" notnull_strength="1" field="T_Id" exp_strength="0" constraints="3"/>
-    <constraint unique_strength="0" notnull_strength="1" field="T_basket" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="T_Ili_Tid" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="geomquality" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="assetitem_assetitem" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="1" field="assetitem_lg_geolssts_v2geolassets_assetitem" exp_strength="0" constraints="1"/>
+    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="1" constraints="2" field="T_Ili_Tid" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="geomquality" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="assetitem_assetitem" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="assetitem_lg_geolssts_v2geolassets_assetitem" notnull_strength="1" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="T_Id" desc="" exp=""/>
-    <constraint field="T_basket" desc="" exp=""/>
-    <constraint field="T_Ili_Tid" desc="" exp=""/>
-    <constraint field="geomquality" desc="" exp=""/>
-    <constraint field="assetitem_assetitem" desc="" exp=""/>
-    <constraint field="assetitem_lg_geolssts_v2geolassets_assetitem" desc="" exp=""/>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="T_Ili_Tid" desc=""/>
+    <constraint exp="" field="geomquality" desc=""/>
+    <constraint exp="" field="assetitem_assetitem" desc=""/>
+    <constraint exp="" field="assetitem_lg_geolssts_v2geolassets_assetitem" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <editform tolerant="1"></editform>
@@ -611,8 +611,8 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField showLabel="1" name="geomquality" index="3"/>
-    <attributeEditorField showLabel="1" name="assetitem_lg_geolssts_v2geolassets_assetitem" index="5"/>
+    <attributeEditorField name="geomquality" index="3" showLabel="1"/>
+    <attributeEditorField name="assetitem_lg_geolssts_v2geolassets_assetitem" index="5" showLabel="1"/>
   </attributeEditorForm>
   <editable>
     <field name="T_Id" editable="1"/>
@@ -623,12 +623,12 @@ def my_form_open(dialog, layer, feature):
     <field name="geomquality" editable="1"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="T_Id"/>
-    <field labelOnTop="0" name="T_Ili_Tid"/>
-    <field labelOnTop="0" name="T_basket"/>
-    <field labelOnTop="0" name="assetitem_assetitem"/>
-    <field labelOnTop="0" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
-    <field labelOnTop="0" name="geomquality"/>
+    <field name="T_Id" labelOnTop="0"/>
+    <field name="T_Ili_Tid" labelOnTop="0"/>
+    <field name="T_basket" labelOnTop="0"/>
+    <field name="assetitem_assetitem" labelOnTop="0"/>
+    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" labelOnTop="0"/>
+    <field name="geomquality" labelOnTop="0"/>
   </labelOnTop>
   <reuseLastValue>
     <field reuseLastValue="0" name="T_Id"/>

--- a/lg_geolassets_v2/layerstyle/studytrace.qml
+++ b/lg_geolassets_v2/layerstyle/studytrace.qml
@@ -6,426 +6,426 @@
     <Searchable>1</Searchable>
     <Private>0</Private>
   </flags>
-  <renderer-v2 forceraster="0" type="RuleRenderer" enableorderby="0" referencescale="-1" symbollevels="0">
+  <renderer-v2 enableorderby="0" referencescale="-1" symbollevels="0" forceraster="0" type="RuleRenderer">
     <rules key="{ab1280f2-2679-4bf3-983c-a64ae95ed90b}">
-      <rule filter="ELSE" symbol="0" label="Not Available" key="{f17db51f-9ff4-4de5-8de1-f28d49da7f9f}"/>
-      <rule filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') " symbol="1" label="Internal" key="{3b381cd0-ec36-4b75-bf8b-3938a400fd0a}"/>
-      <rule filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" symbol="2" label="Public" key="{215f31f7-d1f8-4e65-bc9b-06fc41d91e04}"/>
+      <rule symbol="0" filter="attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{215f31f7-d1f8-4e65-bc9b-06fc41d91e04}" label="Public"/>
+      <rule symbol="1" filter="attribute(get_feature('InternalUse', 'lg_glssts_vssts_ssttem_internaluse',&quot;assetitem_lg_geolssts_v2geolassets_assetitem&quot; ),'isavailable') &#xa;AND NOT attribute(get_feature('PublicUse', 'lg_glssts_vssts_ssttem_publicuse',assetitem_lg_geolssts_v2geolassets_assetitem),'isavailable')" key="{3ca8135d-93fe-4541-b88f-e05c07899cdf}" label="Internal"/>
+      <rule symbol="2" filter="ELSE" key="{94727ae0-58cd-4fb4-96d6-b68cd947a971}" label="Not Available"/>
     </rules>
     <symbols>
-      <symbol force_rhr="0" alpha="1" type="line" clip_to_extent="1" name="0">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="0" type="line">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleLine" locked="0">
+        <layer pass="0" class="SimpleLine" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="align_dash_pattern"/>
-            <Option value="round" type="QString" name="capstyle"/>
-            <Option value="5;2" type="QString" name="customdash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
-            <Option value="MM" type="QString" name="customdash_unit"/>
-            <Option value="0" type="QString" name="dash_pattern_offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
-            <Option value="0" type="QString" name="draw_inside_polygon"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0,0,128" type="QString" name="line_color"/>
-            <Option value="solid" type="QString" name="line_style"/>
-            <Option value="1.66" type="QString" name="line_width"/>
-            <Option value="MM" type="QString" name="line_width_unit"/>
-            <Option value="0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0" type="QString" name="ring_filter"/>
-            <Option value="0" type="QString" name="trim_distance_end"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
-            <Option value="0" type="QString" name="trim_distance_start"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
-            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
-            <Option value="0" type="QString" name="use_custom_dash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+            <Option value="0" name="align_dash_pattern" type="QString"/>
+            <Option value="round" name="capstyle" type="QString"/>
+            <Option value="5;2" name="customdash" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+            <Option value="MM" name="customdash_unit" type="QString"/>
+            <Option value="0" name="dash_pattern_offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+            <Option value="0" name="draw_inside_polygon" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0,0,128" name="line_color" type="QString"/>
+            <Option value="solid" name="line_style" type="QString"/>
+            <Option value="1.66" name="line_width" type="QString"/>
+            <Option value="MM" name="line_width_unit" type="QString"/>
+            <Option value="0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0" name="ring_filter" type="QString"/>
+            <Option value="0" name="trim_distance_end" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+            <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+            <Option value="0" name="trim_distance_start" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+            <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+            <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+            <Option value="0" name="use_custom_dash" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern"/>
-          <prop v="round" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="dash_pattern_offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-          <prop v="MM" k="dash_pattern_offset_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0,0,128" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="1.66" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="trim_distance_end"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_end_unit"/>
-          <prop v="0" k="trim_distance_start"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_start_unit"/>
-          <prop v="0" k="tweak_dash_pattern_on_corners"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="round"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="0,0,0,128"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="1.66"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer enabled="1" pass="0" class="SimpleLine" locked="0">
+        <layer pass="0" class="SimpleLine" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="align_dash_pattern"/>
-            <Option value="round" type="QString" name="capstyle"/>
-            <Option value="5;2" type="QString" name="customdash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
-            <Option value="MM" type="QString" name="customdash_unit"/>
-            <Option value="0" type="QString" name="dash_pattern_offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
-            <Option value="0" type="QString" name="draw_inside_polygon"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="246,71,137,255" type="QString" name="line_color"/>
-            <Option value="solid" type="QString" name="line_style"/>
-            <Option value="0.46" type="QString" name="line_width"/>
-            <Option value="MM" type="QString" name="line_width_unit"/>
-            <Option value="0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0" type="QString" name="ring_filter"/>
-            <Option value="0" type="QString" name="trim_distance_end"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
-            <Option value="0" type="QString" name="trim_distance_start"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
-            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
-            <Option value="0" type="QString" name="use_custom_dash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+            <Option value="0" name="align_dash_pattern" type="QString"/>
+            <Option value="round" name="capstyle" type="QString"/>
+            <Option value="5;2" name="customdash" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+            <Option value="MM" name="customdash_unit" type="QString"/>
+            <Option value="0" name="dash_pattern_offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+            <Option value="0" name="draw_inside_polygon" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="218,253,216,255" name="line_color" type="QString"/>
+            <Option value="solid" name="line_style" type="QString"/>
+            <Option value="0.46" name="line_width" type="QString"/>
+            <Option value="MM" name="line_width_unit" type="QString"/>
+            <Option value="0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0" name="ring_filter" type="QString"/>
+            <Option value="0" name="trim_distance_end" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+            <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+            <Option value="0" name="trim_distance_start" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+            <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+            <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+            <Option value="0" name="use_custom_dash" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern"/>
-          <prop v="round" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="dash_pattern_offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-          <prop v="MM" k="dash_pattern_offset_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="246,71,137,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.46" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="trim_distance_end"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_end_unit"/>
-          <prop v="0" k="trim_distance_start"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_start_unit"/>
-          <prop v="0" k="tweak_dash_pattern_on_corners"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="round"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="218,253,216,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.46"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="line" clip_to_extent="1" name="1">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="1" type="line">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleLine" locked="0">
+        <layer pass="0" class="SimpleLine" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="align_dash_pattern"/>
-            <Option value="round" type="QString" name="capstyle"/>
-            <Option value="5;2" type="QString" name="customdash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
-            <Option value="MM" type="QString" name="customdash_unit"/>
-            <Option value="0" type="QString" name="dash_pattern_offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
-            <Option value="0" type="QString" name="draw_inside_polygon"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0,0,128" type="QString" name="line_color"/>
-            <Option value="solid" type="QString" name="line_style"/>
-            <Option value="1.66" type="QString" name="line_width"/>
-            <Option value="MM" type="QString" name="line_width_unit"/>
-            <Option value="0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0" type="QString" name="ring_filter"/>
-            <Option value="0" type="QString" name="trim_distance_end"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
-            <Option value="0" type="QString" name="trim_distance_start"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
-            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
-            <Option value="0" type="QString" name="use_custom_dash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+            <Option value="0" name="align_dash_pattern" type="QString"/>
+            <Option value="round" name="capstyle" type="QString"/>
+            <Option value="5;2" name="customdash" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+            <Option value="MM" name="customdash_unit" type="QString"/>
+            <Option value="0" name="dash_pattern_offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+            <Option value="0" name="draw_inside_polygon" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0,0,128" name="line_color" type="QString"/>
+            <Option value="solid" name="line_style" type="QString"/>
+            <Option value="1.66" name="line_width" type="QString"/>
+            <Option value="MM" name="line_width_unit" type="QString"/>
+            <Option value="0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0" name="ring_filter" type="QString"/>
+            <Option value="0" name="trim_distance_end" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+            <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+            <Option value="0" name="trim_distance_start" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+            <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+            <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+            <Option value="0" name="use_custom_dash" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern"/>
-          <prop v="round" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="dash_pattern_offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-          <prop v="MM" k="dash_pattern_offset_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0,0,128" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="1.66" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="trim_distance_end"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_end_unit"/>
-          <prop v="0" k="trim_distance_start"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_start_unit"/>
-          <prop v="0" k="tweak_dash_pattern_on_corners"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="round"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="0,0,0,128"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="1.66"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer enabled="1" pass="0" class="SimpleLine" locked="0">
+        <layer pass="0" class="SimpleLine" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="align_dash_pattern"/>
-            <Option value="round" type="QString" name="capstyle"/>
-            <Option value="5;2" type="QString" name="customdash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
-            <Option value="MM" type="QString" name="customdash_unit"/>
-            <Option value="0" type="QString" name="dash_pattern_offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
-            <Option value="0" type="QString" name="draw_inside_polygon"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="254,209,147,255" type="QString" name="line_color"/>
-            <Option value="solid" type="QString" name="line_style"/>
-            <Option value="0.46" type="QString" name="line_width"/>
-            <Option value="MM" type="QString" name="line_width_unit"/>
-            <Option value="0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0" type="QString" name="ring_filter"/>
-            <Option value="0" type="QString" name="trim_distance_end"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
-            <Option value="0" type="QString" name="trim_distance_start"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
-            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
-            <Option value="0" type="QString" name="use_custom_dash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+            <Option value="0" name="align_dash_pattern" type="QString"/>
+            <Option value="round" name="capstyle" type="QString"/>
+            <Option value="5;2" name="customdash" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+            <Option value="MM" name="customdash_unit" type="QString"/>
+            <Option value="0" name="dash_pattern_offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+            <Option value="0" name="draw_inside_polygon" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="254,209,147,255" name="line_color" type="QString"/>
+            <Option value="solid" name="line_style" type="QString"/>
+            <Option value="0.46" name="line_width" type="QString"/>
+            <Option value="MM" name="line_width_unit" type="QString"/>
+            <Option value="0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0" name="ring_filter" type="QString"/>
+            <Option value="0" name="trim_distance_end" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+            <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+            <Option value="0" name="trim_distance_start" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+            <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+            <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+            <Option value="0" name="use_custom_dash" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern"/>
-          <prop v="round" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="dash_pattern_offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-          <prop v="MM" k="dash_pattern_offset_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="254,209,147,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.46" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="trim_distance_end"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_end_unit"/>
-          <prop v="0" k="trim_distance_start"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_start_unit"/>
-          <prop v="0" k="tweak_dash_pattern_on_corners"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="round"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="254,209,147,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.46"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol force_rhr="0" alpha="1" type="line" clip_to_extent="1" name="2">
+      <symbol clip_to_extent="1" alpha="1" force_rhr="0" name="2" type="line">
         <data_defined_properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option value="collection" type="QString" name="type"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data_defined_properties>
-        <layer enabled="1" pass="0" class="SimpleLine" locked="0">
+        <layer pass="0" class="SimpleLine" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="align_dash_pattern"/>
-            <Option value="round" type="QString" name="capstyle"/>
-            <Option value="5;2" type="QString" name="customdash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
-            <Option value="MM" type="QString" name="customdash_unit"/>
-            <Option value="0" type="QString" name="dash_pattern_offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
-            <Option value="0" type="QString" name="draw_inside_polygon"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="0,0,0,128" type="QString" name="line_color"/>
-            <Option value="solid" type="QString" name="line_style"/>
-            <Option value="1.66" type="QString" name="line_width"/>
-            <Option value="MM" type="QString" name="line_width_unit"/>
-            <Option value="0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0" type="QString" name="ring_filter"/>
-            <Option value="0" type="QString" name="trim_distance_end"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
-            <Option value="0" type="QString" name="trim_distance_start"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
-            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
-            <Option value="0" type="QString" name="use_custom_dash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+            <Option value="0" name="align_dash_pattern" type="QString"/>
+            <Option value="round" name="capstyle" type="QString"/>
+            <Option value="5;2" name="customdash" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+            <Option value="MM" name="customdash_unit" type="QString"/>
+            <Option value="0" name="dash_pattern_offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+            <Option value="0" name="draw_inside_polygon" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="0,0,0,128" name="line_color" type="QString"/>
+            <Option value="solid" name="line_style" type="QString"/>
+            <Option value="1.66" name="line_width" type="QString"/>
+            <Option value="MM" name="line_width_unit" type="QString"/>
+            <Option value="0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0" name="ring_filter" type="QString"/>
+            <Option value="0" name="trim_distance_end" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+            <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+            <Option value="0" name="trim_distance_start" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+            <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+            <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+            <Option value="0" name="use_custom_dash" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern"/>
-          <prop v="round" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="dash_pattern_offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-          <prop v="MM" k="dash_pattern_offset_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0,0,128" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="1.66" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="trim_distance_end"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_end_unit"/>
-          <prop v="0" k="trim_distance_start"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_start_unit"/>
-          <prop v="0" k="tweak_dash_pattern_on_corners"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="round"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="0,0,0,128"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="1.66"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
-        <layer enabled="1" pass="0" class="SimpleLine" locked="0">
+        <layer pass="0" class="SimpleLine" locked="0" enabled="1">
           <Option type="Map">
-            <Option value="0" type="QString" name="align_dash_pattern"/>
-            <Option value="round" type="QString" name="capstyle"/>
-            <Option value="5;2" type="QString" name="customdash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="customdash_map_unit_scale"/>
-            <Option value="MM" type="QString" name="customdash_unit"/>
-            <Option value="0" type="QString" name="dash_pattern_offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="dash_pattern_offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="dash_pattern_offset_unit"/>
-            <Option value="0" type="QString" name="draw_inside_polygon"/>
-            <Option value="bevel" type="QString" name="joinstyle"/>
-            <Option value="218,253,216,255" type="QString" name="line_color"/>
-            <Option value="solid" type="QString" name="line_style"/>
-            <Option value="0.46" type="QString" name="line_width"/>
-            <Option value="MM" type="QString" name="line_width_unit"/>
-            <Option value="0" type="QString" name="offset"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
-            <Option value="MM" type="QString" name="offset_unit"/>
-            <Option value="0" type="QString" name="ring_filter"/>
-            <Option value="0" type="QString" name="trim_distance_end"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_end_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_end_unit"/>
-            <Option value="0" type="QString" name="trim_distance_start"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="trim_distance_start_map_unit_scale"/>
-            <Option value="MM" type="QString" name="trim_distance_start_unit"/>
-            <Option value="0" type="QString" name="tweak_dash_pattern_on_corners"/>
-            <Option value="0" type="QString" name="use_custom_dash"/>
-            <Option value="3x:0,0,0,0,0,0" type="QString" name="width_map_unit_scale"/>
+            <Option value="0" name="align_dash_pattern" type="QString"/>
+            <Option value="round" name="capstyle" type="QString"/>
+            <Option value="5;2" name="customdash" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+            <Option value="MM" name="customdash_unit" type="QString"/>
+            <Option value="0" name="dash_pattern_offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+            <Option value="0" name="draw_inside_polygon" type="QString"/>
+            <Option value="bevel" name="joinstyle" type="QString"/>
+            <Option value="246,71,137,255" name="line_color" type="QString"/>
+            <Option value="solid" name="line_style" type="QString"/>
+            <Option value="0.46" name="line_width" type="QString"/>
+            <Option value="MM" name="line_width_unit" type="QString"/>
+            <Option value="0" name="offset" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+            <Option value="MM" name="offset_unit" type="QString"/>
+            <Option value="0" name="ring_filter" type="QString"/>
+            <Option value="0" name="trim_distance_end" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+            <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+            <Option value="0" name="trim_distance_start" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+            <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+            <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+            <Option value="0" name="use_custom_dash" type="QString"/>
+            <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
           </Option>
-          <prop v="0" k="align_dash_pattern"/>
-          <prop v="round" k="capstyle"/>
-          <prop v="5;2" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="MM" k="customdash_unit"/>
-          <prop v="0" k="dash_pattern_offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="dash_pattern_offset_map_unit_scale"/>
-          <prop v="MM" k="dash_pattern_offset_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="218,253,216,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="0.46" k="line_width"/>
-          <prop v="MM" k="line_width_unit"/>
-          <prop v="0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="0" k="trim_distance_end"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_end_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_end_unit"/>
-          <prop v="0" k="trim_distance_start"/>
-          <prop v="3x:0,0,0,0,0,0" k="trim_distance_start_map_unit_scale"/>
-          <prop v="MM" k="trim_distance_start_unit"/>
-          <prop v="0" k="tweak_dash_pattern_on_corners"/>
-          <prop v="0" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+          <prop k="align_dash_pattern" v="0"/>
+          <prop k="capstyle" v="round"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="dash_pattern_offset" v="0"/>
+          <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="dash_pattern_offset_unit" v="MM"/>
+          <prop k="draw_inside_polygon" v="0"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="line_color" v="246,71,137,255"/>
+          <prop k="line_style" v="solid"/>
+          <prop k="line_width" v="0.46"/>
+          <prop k="line_width_unit" v="MM"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="ring_filter" v="0"/>
+          <prop k="trim_distance_end" v="0"/>
+          <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_end_unit" v="MM"/>
+          <prop k="trim_distance_start" v="0"/>
+          <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="trim_distance_start_unit" v="MM"/>
+          <prop k="tweak_dash_pattern_on_corners" v="0"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option value="" name="name" type="QString"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option value="collection" name="type" type="QString"/>
             </Option>
           </data_defined_properties>
         </layer>
@@ -434,17 +434,17 @@
   </renderer-v2>
   <customproperties>
     <Option type="Map">
-      <Option value="copy" type="QString" name="QFieldSync/action"/>
-      <Option value="offline" type="QString" name="QFieldSync/cloud_action"/>
-      <Option value="{}" type="QString" name="QFieldSync/photo_naming"/>
-      <Option type="List" name="dualview/previewExpressions">
+      <Option value="copy" name="QFieldSync/action" type="QString"/>
+      <Option value="offline" name="QFieldSync/cloud_action" type="QString"/>
+      <Option value="{}" name="QFieldSync/photo_naming" type="QString"/>
+      <Option name="dualview/previewExpressions" type="List">
         <Option value="if(length(geom_to_wkt( $geometry ))>22,substr(geom_to_wkt( $geometry ),0,23)||'...',geom_to_wkt( $geometry ))" type="QString"/>
       </Option>
-      <Option value="0" type="int" name="embeddedWidgets/count"/>
-      <Option type="StringList" name="variableNames">
+      <Option value="0" name="embeddedWidgets/count" type="int"/>
+      <Option name="variableNames" type="StringList">
         <Option value="interlis_topic" type="QString"/>
       </Option>
-      <Option type="StringList" name="variableValues">
+      <Option name="variableValues" type="StringList">
         <Option value="LG_GeolAssets_V2.GeolAssets" type="QString"/>
       </Option>
     </Option>
@@ -452,105 +452,105 @@
   <blendMode>0</blendMode>
   <featureBlendMode>0</featureBlendMode>
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id">
+    <field name="T_Id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_basket">
+    <field name="T_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="false" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="&quot;topic&quot; ='LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" type="QString" name="ReferencedLayerId"/>
-            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studytrace_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option value="false" name="AllowAddFeatures" type="bool"/>
+            <Option value="false" name="AllowNULL" type="bool"/>
+            <Option value="false" name="ChainFilters" type="bool"/>
+            <Option value="&quot;topic&quot; ='LGGeolAssets_V2.GeolAssets' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" name="FilterExpression" type="QString"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option value="false" name="MapIdentification" type="bool"/>
+            <Option value="true" name="OrderByValue" type="bool"/>
+            <Option value="false" name="ReadOnly" type="bool"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" name="ReferencedLayerDataSource" type="QString"/>
+            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" name="ReferencedLayerId" type="QString"/>
+            <Option value="T_ILI2DB_BASKET" name="ReferencedLayerName" type="QString"/>
+            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
+            <Option value="studytrace_T_basket_T_ILI2DB_BASKET_T_Id" name="Relation" type="QString"/>
+            <Option value="false" name="ShowForm" type="bool"/>
+            <Option value="false" name="ShowOpenFormButton" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_Ili_Tid">
+    <field name="T_Ili_Tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="IsMultiline"/>
-            <Option value="false" type="bool" name="UseHtml"/>
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="geomquality">
+    <field name="geomquality" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8" type="QString" name="ReferencedLayerId"/>
-            <Option value="GeomQualityItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studytrace_geomquality_geomqualityitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option value="false" name="AllowAddFeatures" type="bool"/>
+            <Option value="true" name="AllowNULL" type="bool"/>
+            <Option value="false" name="ChainFilters" type="bool"/>
+            <Option value="" name="FilterExpression" type="QString"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option value="false" name="MapIdentification" type="bool"/>
+            <Option value="true" name="OrderByValue" type="bool"/>
+            <Option value="false" name="ReadOnly" type="bool"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=geomqualityitem" name="ReferencedLayerDataSource" type="QString"/>
+            <Option value="GeomQualityItem_d5e58ca5_2d80_4618_8ce6_3a17f2dcbed8" name="ReferencedLayerId" type="QString"/>
+            <Option value="GeomQualityItem" name="ReferencedLayerName" type="QString"/>
+            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
+            <Option value="studytrace_geomquality_geomqualityitem_T_Id" name="Relation" type="QString"/>
+            <Option value="false" name="ShowForm" type="bool"/>
+            <Option value="false" name="ShowOpenFormButton" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="assetitem_assetitem">
+    <field name="assetitem_assetitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="true" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e" type="QString" name="ReferencedLayerId"/>
-            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studytrace_assetitem_assetitem_assetitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option value="true" name="AllowAddFeatures" type="bool"/>
+            <Option value="true" name="AllowNULL" type="bool"/>
+            <Option value="false" name="MapIdentification" type="bool"/>
+            <Option value="true" name="OrderByValue" type="bool"/>
+            <Option value="false" name="ReadOnly" type="bool"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=assetitem" name="ReferencedLayerDataSource" type="QString"/>
+            <Option value="AssetItem_f833c131_b74c_463e_9eba_18f17a3cf41e" name="ReferencedLayerId" type="QString"/>
+            <Option value="AssetItem" name="ReferencedLayerName" type="QString"/>
+            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
+            <Option value="studytrace_assetitem_assetitem_assetitem_T_Id" name="Relation" type="QString"/>
+            <Option value="false" name="ShowForm" type="bool"/>
+            <Option value="false" name="ShowOpenFormButton" type="bool"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="assetitem_lg_geolssts_v2geolassets_assetitem">
+    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d" type="QString" name="ReferencedLayerId"/>
-            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="studytrace_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="true" type="bool" name="ShowOpenFormButton"/>
+            <Option value="false" name="AllowAddFeatures" type="bool"/>
+            <Option value="true" name="AllowNULL" type="bool"/>
+            <Option value="false" name="MapIdentification" type="bool"/>
+            <Option value="true" name="OrderByValue" type="bool"/>
+            <Option value="false" name="ReadOnly" type="bool"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" name="ReferencedLayerDataSource" type="QString"/>
+            <Option value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d" name="ReferencedLayerId" type="QString"/>
+            <Option value="AssetItem" name="ReferencedLayerName" type="QString"/>
+            <Option value="ogr" name="ReferencedLayerProviderKey" type="QString"/>
+            <Option value="studytrace_assetitem_lg_geolssts_v2geolassets_assetitem_lg_geolssts_v2geolassets_assetitem_T_Id" name="Relation" type="QString"/>
+            <Option value="false" name="ShowForm" type="bool"/>
+            <Option value="true" name="ShowOpenFormButton" type="bool"/>
           </Option>
         </config>
       </editWidget>
@@ -565,28 +565,28 @@
     <alias field="assetitem_lg_geolssts_v2geolassets_assetitem" index="5" name="AssetItem"/>
   </aliases>
   <defaults>
-    <default expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" field="T_Id" applyOnUpdate="0"/>
-    <default expression="@default_basket_lg_geolassets_v2_geolassets" field="T_basket" applyOnUpdate="0"/>
-    <default expression="substr(uuid(), 2, 36)" field="T_Ili_Tid" applyOnUpdate="0"/>
-    <default expression="" field="geomquality" applyOnUpdate="0"/>
-    <default expression="" field="assetitem_assetitem" applyOnUpdate="0"/>
-    <default expression="" field="assetitem_lg_geolssts_v2geolassets_assetitem" applyOnUpdate="0"/>
+    <default field="T_Id" applyOnUpdate="0" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
+    <default field="T_basket" applyOnUpdate="0" expression="@default_basket_lg_geolassets_v2_geolassets"/>
+    <default field="T_Ili_Tid" applyOnUpdate="0" expression="substr(uuid(), 2, 36)"/>
+    <default field="geomquality" applyOnUpdate="0" expression=""/>
+    <default field="assetitem_assetitem" applyOnUpdate="0" expression=""/>
+    <default field="assetitem_lg_geolssts_v2geolassets_assetitem" applyOnUpdate="0" expression=""/>
   </defaults>
   <constraints>
-    <constraint field="T_Id" exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3"/>
-    <constraint field="T_basket" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
-    <constraint field="T_Ili_Tid" exp_strength="0" unique_strength="1" notnull_strength="0" constraints="2"/>
-    <constraint field="geomquality" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
-    <constraint field="assetitem_assetitem" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
-    <constraint field="assetitem_lg_geolssts_v2geolassets_assetitem" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint field="T_Id" notnull_strength="1" unique_strength="1" exp_strength="0" constraints="3"/>
+    <constraint field="T_basket" notnull_strength="1" unique_strength="0" exp_strength="0" constraints="1"/>
+    <constraint field="T_Ili_Tid" notnull_strength="0" unique_strength="1" exp_strength="0" constraints="2"/>
+    <constraint field="geomquality" notnull_strength="0" unique_strength="0" exp_strength="0" constraints="0"/>
+    <constraint field="assetitem_assetitem" notnull_strength="0" unique_strength="0" exp_strength="0" constraints="0"/>
+    <constraint field="assetitem_lg_geolssts_v2geolassets_assetitem" notnull_strength="1" unique_strength="0" exp_strength="0" constraints="1"/>
   </constraints>
   <constraintExpressions>
-    <constraint exp="" field="T_Id" desc=""/>
-    <constraint exp="" field="T_basket" desc=""/>
-    <constraint exp="" field="T_Ili_Tid" desc=""/>
-    <constraint exp="" field="geomquality" desc=""/>
-    <constraint exp="" field="assetitem_assetitem" desc=""/>
-    <constraint exp="" field="assetitem_lg_geolssts_v2geolassets_assetitem" desc=""/>
+    <constraint field="T_Id" desc="" exp=""/>
+    <constraint field="T_basket" desc="" exp=""/>
+    <constraint field="T_Ili_Tid" desc="" exp=""/>
+    <constraint field="geomquality" desc="" exp=""/>
+    <constraint field="assetitem_assetitem" desc="" exp=""/>
+    <constraint field="assetitem_lg_geolssts_v2geolassets_assetitem" desc="" exp=""/>
   </constraintExpressions>
   <expressionfields/>
   <editform tolerant="1"></editform>
@@ -611,8 +611,8 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField index="3" showLabel="1" name="geomquality"/>
-    <attributeEditorField index="5" showLabel="1" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
+    <attributeEditorField index="3" name="geomquality" showLabel="1"/>
+    <attributeEditorField index="5" name="assetitem_lg_geolssts_v2geolassets_assetitem" showLabel="1"/>
   </attributeEditorForm>
   <editable>
     <field editable="1" name="T_Id"/>
@@ -631,12 +631,12 @@ def my_form_open(dialog, layer, feature):
     <field labelOnTop="0" name="geomquality"/>
   </labelOnTop>
   <reuseLastValue>
-    <field reuseLastValue="0" name="T_Id"/>
-    <field reuseLastValue="0" name="T_Ili_Tid"/>
-    <field reuseLastValue="0" name="T_basket"/>
-    <field reuseLastValue="0" name="assetitem_assetitem"/>
-    <field reuseLastValue="0" name="assetitem_lg_geolssts_v2geolassets_assetitem"/>
-    <field reuseLastValue="0" name="geomquality"/>
+    <field name="T_Id" reuseLastValue="0"/>
+    <field name="T_Ili_Tid" reuseLastValue="0"/>
+    <field name="T_basket" reuseLastValue="0"/>
+    <field name="assetitem_assetitem" reuseLastValue="0"/>
+    <field name="assetitem_lg_geolssts_v2geolassets_assetitem" reuseLastValue="0"/>
+    <field name="geomquality" reuseLastValue="0"/>
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>

--- a/lg_geolassets_v2/layerstyle/typenatrel.qml
+++ b/lg_geolassets_v2/layerstyle/typenatrel.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="LayerConfiguration|Fields|Forms" readOnly="0" version="3.25.0-Master">
+<qgis styleCategories="LayerConfiguration|Fields|Forms" readOnly="0" version="3.24.3-Tisler">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -7,125 +7,125 @@
     <Private>0</Private>
   </flags>
   <fieldConfiguration>
-    <field configurationFlags="None" name="T_Id">
+    <field name="T_Id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_basket">
+    <field name="T_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="false" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" type="QString" name="ReferencedLayerId"/>
-            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="typenatrel_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="ChainFilters" type="bool" value="false"/>
+            <Option name="FilterExpression" type="QString" value=""/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c"/>
+            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="typenatrel_T_basket_T_ILI2DB_BASKET_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_Ili_Tid">
+    <field name="T_Ili_Tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="T_Seq">
+    <field name="T_Seq" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="typenatrel">
+    <field name="typenatrel" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="ChainFilters"/>
-            <Option value="" type="QString" name="FilterExpression"/>
-            <Option type="invalid" name="FilterFields"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=natrelitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="NatRelItem_fc14958c_24c5_4d9c_8a2b_72c5dfe260f7" type="QString" name="ReferencedLayerId"/>
-            <Option value="NatRelItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="typenatrel_typenatrel_natrelitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="ChainFilters" type="bool" value="false"/>
+            <Option name="FilterExpression" type="QString" value=""/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=natrelitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="NatRelItem_ce5e32b0_a10f_4d63_ac44_3eadbb549666"/>
+            <Option name="ReferencedLayerName" type="QString" value="NatRelItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="typenatrel_typenatrel_natrelitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field configurationFlags="None" name="lg_glssts_vssts_ssttem_typenatrel">
+    <field name="lg_glssts_vssts_ssttem_typenatrel" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="true" type="bool" name="AllowAddFeatures"/>
-            <Option value="true" type="bool" name="AllowNULL"/>
-            <Option value="false" type="bool" name="MapIdentification"/>
-            <Option value="true" type="bool" name="OrderByValue"/>
-            <Option value="false" type="bool" name="ReadOnly"/>
-            <Option value="/home/dave/qgis_project/lg_geolAssets_v2/lg_geolAssets_v2_data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString" name="ReferencedLayerDataSource"/>
-            <Option value="AssetItem_0136352c_7637_4b76_9c5c_c1c927cab0af" type="QString" name="ReferencedLayerId"/>
-            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
-            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
-            <Option value="typenatrel_lg_glssts_vssts_ssttem_typenatrel_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="Relation"/>
-            <Option value="false" type="bool" name="ShowForm"/>
-            <Option value="false" type="bool" name="ShowOpenFormButton"/>
+            <Option name="AllowAddFeatures" type="bool" value="true"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
+            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
+            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
+            <Option name="Relation" type="QString" value="typenatrel_lg_glssts_vssts_ssttem_typenatrel_lg_geolssts_v2geolassets_assetitem_T_Id"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias field="T_Id" index="0" name=""/>
-    <alias field="T_basket" index="1" name=""/>
-    <alias field="T_Ili_Tid" index="2" name=""/>
-    <alias field="T_Seq" index="3" name=""/>
-    <alias field="typenatrel" index="4" name="Typ"/>
-    <alias field="lg_glssts_vssts_ssttem_typenatrel" index="5" name="TypeNatRel"/>
+    <alias name="" index="0" field="T_Id"/>
+    <alias name="" index="1" field="T_basket"/>
+    <alias name="" index="2" field="T_Ili_Tid"/>
+    <alias name="" index="3" field="T_Seq"/>
+    <alias name="Typ" index="4" field="typenatrel"/>
+    <alias name="Asset Item" index="5" field="lg_glssts_vssts_ssttem_typenatrel"/>
   </aliases>
   <defaults>
-    <default field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" applyOnUpdate="0"/>
-    <default field="T_basket" expression="@default_basket" applyOnUpdate="0"/>
-    <default field="T_Ili_Tid" expression="" applyOnUpdate="0"/>
-    <default field="T_Seq" expression="" applyOnUpdate="0"/>
-    <default field="typenatrel" expression="" applyOnUpdate="0"/>
-    <default field="lg_glssts_vssts_ssttem_typenatrel" expression="" applyOnUpdate="0"/>
+    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
+    <default applyOnUpdate="0" field="T_basket" expression="@default_basket"/>
+    <default applyOnUpdate="0" field="T_Ili_Tid" expression=""/>
+    <default applyOnUpdate="0" field="T_Seq" expression=""/>
+    <default applyOnUpdate="0" field="typenatrel" expression=""/>
+    <default applyOnUpdate="0" field="lg_glssts_vssts_ssttem_typenatrel" expression=""/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" notnull_strength="1" field="T_Id" exp_strength="0" constraints="3"/>
-    <constraint unique_strength="0" notnull_strength="1" field="T_basket" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="T_Ili_Tid" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="0" field="T_Seq" exp_strength="0" constraints="0"/>
-    <constraint unique_strength="0" notnull_strength="1" field="typenatrel" exp_strength="0" constraints="1"/>
-    <constraint unique_strength="0" notnull_strength="0" field="lg_glssts_vssts_ssttem_typenatrel" exp_strength="0" constraints="0"/>
+    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="T_Ili_Tid" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="T_Seq" notnull_strength="0" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="1" field="typenatrel" notnull_strength="1" exp_strength="0"/>
+    <constraint unique_strength="0" constraints="0" field="lg_glssts_vssts_ssttem_typenatrel" notnull_strength="0" exp_strength="0"/>
   </constraints>
   <constraintExpressions>
-    <constraint field="T_Id" desc="" exp=""/>
-    <constraint field="T_basket" desc="" exp=""/>
-    <constraint field="T_Ili_Tid" desc="" exp=""/>
-    <constraint field="T_Seq" desc="" exp=""/>
-    <constraint field="typenatrel" desc="" exp=""/>
-    <constraint field="lg_glssts_vssts_ssttem_typenatrel" desc="" exp=""/>
+    <constraint exp="" field="T_Id" desc=""/>
+    <constraint exp="" field="T_basket" desc=""/>
+    <constraint exp="" field="T_Ili_Tid" desc=""/>
+    <constraint exp="" field="T_Seq" desc=""/>
+    <constraint exp="" field="typenatrel" desc=""/>
+    <constraint exp="" field="lg_glssts_vssts_ssttem_typenatrel" desc=""/>
   </constraintExpressions>
   <expressionfields/>
   <editform tolerant="1"></editform>
@@ -150,23 +150,23 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField showLabel="1" name="typenatrel" index="4"/>
+    <attributeEditorField name="lg_glssts_vssts_ssttem_typenatrel" index="5" showLabel="1"/>
   </attributeEditorForm>
   <editable>
     <field name="T_Id" editable="1"/>
     <field name="T_Ili_Tid" editable="1"/>
     <field name="T_Seq" editable="1"/>
     <field name="T_basket" editable="1"/>
-    <field name="lg_glssts_vssts_ssttem_typenatrel" editable="1"/>
+    <field name="lg_glssts_vssts_ssttem_typenatrel" editable="0"/>
     <field name="typenatrel" editable="1"/>
   </editable>
   <labelOnTop>
-    <field labelOnTop="0" name="T_Id"/>
-    <field labelOnTop="0" name="T_Ili_Tid"/>
-    <field labelOnTop="0" name="T_Seq"/>
-    <field labelOnTop="0" name="T_basket"/>
-    <field labelOnTop="0" name="lg_glssts_vssts_ssttem_typenatrel"/>
-    <field labelOnTop="0" name="typenatrel"/>
+    <field name="T_Id" labelOnTop="0"/>
+    <field name="T_Ili_Tid" labelOnTop="0"/>
+    <field name="T_Seq" labelOnTop="0"/>
+    <field name="T_basket" labelOnTop="0"/>
+    <field name="lg_glssts_vssts_ssttem_typenatrel" labelOnTop="0"/>
+    <field name="typenatrel" labelOnTop="0"/>
   </labelOnTop>
   <reuseLastValue>
     <field reuseLastValue="0" name="T_Id"/>
@@ -178,6 +178,6 @@ def my_form_open(dialog, layer, feature):
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>
-  <previewExpression>"T_Ili_Tid"</previewExpression>
+  <previewExpression>attribute(get_feature('AssetItem', 'T_Id',  "lg_glssts_vssts_ssttem_typenatrel" ),'titleoriginal')</previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/layerstyle/typenatrel.qml
+++ b/lg_geolassets_v2/layerstyle/typenatrel.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="LayerConfiguration|Fields|Forms" readOnly="0" version="3.24.3-Tisler">
+<qgis readOnly="0" version="3.22.11-Białowieża" styleCategories="LayerConfiguration|Fields|Forms">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -7,117 +7,117 @@
     <Private>0</Private>
   </flags>
   <fieldConfiguration>
-    <field name="T_Id" configurationFlags="None">
+    <field configurationFlags="None" name="T_Id">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="T_basket" configurationFlags="None">
+    <field configurationFlags="None" name="T_basket">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="ChainFilters" type="bool" value="false"/>
-            <Option name="FilterExpression" type="QString" value=""/>
-            <Option name="FilterFields" type="invalid"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="true"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerId" type="QString" value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c"/>
-            <Option name="ReferencedLayerName" type="QString" value="T_ILI2DB_BASKET"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="typenatrel_T_basket_T_ILI2DB_BASKET_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="false"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="ChainFilters"/>
+            <Option value="" type="QString" name="FilterExpression"/>
+            <Option type="invalid" name="FilterFields"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="true" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/dave/qgis_project/lg_geolAssets_v2_5/lg_geolAssets_v2_data.gpkg|layername=T_ILI2DB_BASKET" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="T_ILI2DB_BASKET_24d5e8f0_9bd3_4c3c_a60d_4ffe4cc4876c" type="QString" name="ReferencedLayerId"/>
+            <Option value="T_ILI2DB_BASKET" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="typenatrel_T_basket_T_ILI2DB_BASKET_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="false" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="T_Ili_Tid" configurationFlags="None">
+    <field configurationFlags="None" name="T_Ili_Tid">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="T_Seq" configurationFlags="None">
+    <field configurationFlags="None" name="T_Seq">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="typenatrel" configurationFlags="None">
+    <field configurationFlags="None" name="typenatrel">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="false"/>
-            <Option name="AllowNULL" type="bool" value="true"/>
-            <Option name="ChainFilters" type="bool" value="false"/>
-            <Option name="FilterExpression" type="QString" value=""/>
-            <Option name="FilterFields" type="invalid"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="true"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=natrelitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="NatRelItem_ce5e32b0_a10f_4d63_ac44_3eadbb549666"/>
-            <Option name="ReferencedLayerName" type="QString" value="NatRelItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="typenatrel_typenatrel_natrelitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="false"/>
+            <Option value="false" type="bool" name="AllowAddFeatures"/>
+            <Option value="true" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="ChainFilters"/>
+            <Option value="" type="QString" name="FilterExpression"/>
+            <Option type="invalid" name="FilterFields"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="true" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=natrelitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="NatRelItem_ce5e32b0_a10f_4d63_ac44_3eadbb549666" type="QString" name="ReferencedLayerId"/>
+            <Option value="NatRelItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="typenatrel_typenatrel_natrelitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="false" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="lg_glssts_vssts_ssttem_typenatrel" configurationFlags="None">
+    <field configurationFlags="None" name="lg_glssts_vssts_ssttem_typenatrel">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option name="AllowAddFeatures" type="bool" value="true"/>
-            <Option name="AllowNULL" type="bool" value="false"/>
-            <Option name="MapIdentification" type="bool" value="false"/>
-            <Option name="OrderByValue" type="bool" value="false"/>
-            <Option name="ReadOnly" type="bool" value="false"/>
-            <Option name="ReferencedLayerDataSource" type="QString" value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem"/>
-            <Option name="ReferencedLayerId" type="QString" value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d"/>
-            <Option name="ReferencedLayerName" type="QString" value="AssetItem"/>
-            <Option name="ReferencedLayerProviderKey" type="QString" value="ogr"/>
-            <Option name="Relation" type="QString" value="typenatrel_lg_glssts_vssts_ssttem_typenatrel_lg_geolssts_v2geolassets_assetitem_T_Id"/>
-            <Option name="ShowForm" type="bool" value="false"/>
-            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+            <Option value="true" type="bool" name="AllowAddFeatures"/>
+            <Option value="false" type="bool" name="AllowNULL"/>
+            <Option value="false" type="bool" name="MapIdentification"/>
+            <Option value="false" type="bool" name="OrderByValue"/>
+            <Option value="false" type="bool" name="ReadOnly"/>
+            <Option value="/home/cheapdave/qgis_projects/geolassets_followup/version_20220830/data.gpkg|layername=lg_geolssts_v2geolassets_assetitem" type="QString" name="ReferencedLayerDataSource"/>
+            <Option value="AssetItem_28a29ea9_d85d_45e9_ad11_c4bf841d4e5d" type="QString" name="ReferencedLayerId"/>
+            <Option value="AssetItem" type="QString" name="ReferencedLayerName"/>
+            <Option value="ogr" type="QString" name="ReferencedLayerProviderKey"/>
+            <Option value="typenatrel_lg_glssts_vssts_ssttem_typenatrel_lg_geolssts_v2geolassets_assetitem_T_Id" type="QString" name="Relation"/>
+            <Option value="false" type="bool" name="ShowForm"/>
+            <Option value="true" type="bool" name="ShowOpenFormButton"/>
           </Option>
         </config>
       </editWidget>
     </field>
   </fieldConfiguration>
   <aliases>
-    <alias name="" index="0" field="T_Id"/>
-    <alias name="" index="1" field="T_basket"/>
-    <alias name="" index="2" field="T_Ili_Tid"/>
-    <alias name="" index="3" field="T_Seq"/>
-    <alias name="Typ" index="4" field="typenatrel"/>
-    <alias name="Asset Item" index="5" field="lg_glssts_vssts_ssttem_typenatrel"/>
+    <alias field="T_Id" index="0" name=""/>
+    <alias field="T_basket" index="1" name=""/>
+    <alias field="T_Ili_Tid" index="2" name=""/>
+    <alias field="T_Seq" index="3" name=""/>
+    <alias field="typenatrel" index="4" name="Typ"/>
+    <alias field="lg_glssts_vssts_ssttem_typenatrel" index="5" name="Asset Item"/>
   </aliases>
   <defaults>
-    <default applyOnUpdate="0" field="T_Id" expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))"/>
-    <default applyOnUpdate="0" field="T_basket" expression="@default_basket"/>
-    <default applyOnUpdate="0" field="T_Ili_Tid" expression=""/>
-    <default applyOnUpdate="0" field="T_Seq" expression=""/>
-    <default applyOnUpdate="0" field="typenatrel" expression=""/>
-    <default applyOnUpdate="0" field="lg_glssts_vssts_ssttem_typenatrel" expression=""/>
+    <default expression="sqlite_fetch_and_increment(@layer, 'T_KEY_OBJECT', 'T_LastUniqueId', 'T_Key', 'T_Id', map('T_LastChange','date(''now'')','T_CreateDate','date(''now'')','T_User','''' || @user_account_name || ''''))" field="T_Id" applyOnUpdate="0"/>
+    <default expression="@default_basket" field="T_basket" applyOnUpdate="0"/>
+    <default expression="" field="T_Ili_Tid" applyOnUpdate="0"/>
+    <default expression="" field="T_Seq" applyOnUpdate="0"/>
+    <default expression="" field="typenatrel" applyOnUpdate="0"/>
+    <default expression="" field="lg_glssts_vssts_ssttem_typenatrel" applyOnUpdate="0"/>
   </defaults>
   <constraints>
-    <constraint unique_strength="1" constraints="3" field="T_Id" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" field="T_basket" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="T_Ili_Tid" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="T_Seq" notnull_strength="0" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="1" field="typenatrel" notnull_strength="1" exp_strength="0"/>
-    <constraint unique_strength="0" constraints="0" field="lg_glssts_vssts_ssttem_typenatrel" notnull_strength="0" exp_strength="0"/>
+    <constraint field="T_Id" exp_strength="0" unique_strength="1" notnull_strength="1" constraints="3"/>
+    <constraint field="T_basket" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint field="T_Ili_Tid" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="T_Seq" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
+    <constraint field="typenatrel" exp_strength="0" unique_strength="0" notnull_strength="1" constraints="1"/>
+    <constraint field="lg_glssts_vssts_ssttem_typenatrel" exp_strength="0" unique_strength="0" notnull_strength="0" constraints="0"/>
   </constraints>
   <constraintExpressions>
     <constraint exp="" field="T_Id" desc=""/>
@@ -150,23 +150,23 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorField name="lg_glssts_vssts_ssttem_typenatrel" index="5" showLabel="1"/>
+    <attributeEditorField index="5" showLabel="1" name="lg_glssts_vssts_ssttem_typenatrel"/>
   </attributeEditorForm>
   <editable>
-    <field name="T_Id" editable="1"/>
-    <field name="T_Ili_Tid" editable="1"/>
-    <field name="T_Seq" editable="1"/>
-    <field name="T_basket" editable="1"/>
-    <field name="lg_glssts_vssts_ssttem_typenatrel" editable="0"/>
-    <field name="typenatrel" editable="1"/>
+    <field editable="1" name="T_Id"/>
+    <field editable="1" name="T_Ili_Tid"/>
+    <field editable="1" name="T_Seq"/>
+    <field editable="1" name="T_basket"/>
+    <field editable="0" name="lg_glssts_vssts_ssttem_typenatrel"/>
+    <field editable="1" name="typenatrel"/>
   </editable>
   <labelOnTop>
-    <field name="T_Id" labelOnTop="0"/>
-    <field name="T_Ili_Tid" labelOnTop="0"/>
-    <field name="T_Seq" labelOnTop="0"/>
-    <field name="T_basket" labelOnTop="0"/>
-    <field name="lg_glssts_vssts_ssttem_typenatrel" labelOnTop="0"/>
-    <field name="typenatrel" labelOnTop="0"/>
+    <field labelOnTop="0" name="T_Id"/>
+    <field labelOnTop="0" name="T_Ili_Tid"/>
+    <field labelOnTop="0" name="T_Seq"/>
+    <field labelOnTop="0" name="T_basket"/>
+    <field labelOnTop="0" name="lg_glssts_vssts_ssttem_typenatrel"/>
+    <field labelOnTop="0" name="typenatrel"/>
   </labelOnTop>
   <reuseLastValue>
     <field reuseLastValue="0" name="T_Id"/>
@@ -178,6 +178,7 @@ def my_form_open(dialog, layer, feature):
   </reuseLastValue>
   <dataDefinedFieldProperties/>
   <widgets/>
-  <previewExpression>attribute(get_feature('AssetItem', 'T_Id',  "lg_glssts_vssts_ssttem_typenatrel" ),'titleoriginal')</previewExpression>
+  <previewExpression>coalesce( attribute(get_feature('AssetItem', 'T_Id', "lg_glssts_vssts_ssttem_typenatrel"),'titlepublic'),'Kein Öffentlicher Titel vorhanden' )
+</previewExpression>
   <layerGeometryType>4</layerGeometryType>
 </qgis>

--- a/lg_geolassets_v2/projecttopping/lg_geolassets_v2_gpkg.yaml
+++ b/lg_geolassets_v2/projecttopping/lg_geolassets_v2_gpkg.yaml
@@ -50,6 +50,7 @@ layertree:
                     - "LegalDoc":
                         qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_legaldoc"
                     - "ManCatLabelRef":
+                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_mancatlabelref"
             - "Domänentabellen":
                 group: true
                 expanded: false

--- a/lg_geolassets_v2/projecttopping/lg_geolassets_v2_gpkg.yaml
+++ b/lg_geolassets_v2/projecttopping/lg_geolassets_v2_gpkg.yaml
@@ -27,60 +27,111 @@ layertree:
         group: true
         expanded: false
         child-nodes:
-            - "Strukturtabellen":
+        - "Strukturen":
+            group: true
+            expanded: false
+            child-nodes:
+            - "Address":
+                qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_address"
+            - "ID":
+                qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_id"
+            - "TypeNatRel":
+                qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_typenatrel"
+            - "StatusWork":
+                qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_statuswork"
+            - "AutoCat":
+                qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_autocat"
+            - "InternalUse":
+                qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_internaluse"
+            - "PublicUse":
+                qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_publicuse"
+            - "AssetObjectInfo":
+                qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetobjectinfo"
+            - "LegalDoc":
+                qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_legaldoc"
+        - "Domänen":
+            group: true
+            expanded: false
+            child-nodes:
+            - "Items":
                 group: true
                 expanded: false
                 child-nodes:
-                    - "Address":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_address"
-                    - "ID":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_id"
-                    - "TypeNatRel":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_typenatrel"
-                    - "StatusWork":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_statuswork"
-                    - "AutoCat":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_autocat"
-                    - "InternalUse":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_internaluse"
-                    - "PublicUse":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_publicuse"
-                    - "AssetObjectInfo":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetobjectinfo"
-                    - "LegalDoc":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_legaldoc"
-                    - "ManCatLabelRef":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_mancatlabelref"
-            - "Domänentabellen":
+                - "ManCatLabelItem":
+                    qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_mancatlabelitem"
+                - "AssetKindItem":
+                    qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetkinditem"
+                - "AssetFormatItem":
+                    qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetformatitem"
+                - "NatRelItem":
+                    qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_natrelitem"
+                - "StatusWorkItem":
+                    qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_statusworkitem"
+                - "GeomQualityItem":
+                - "LanguageItem":
+                - "ContactKindItem":
+                - "StatusAssetUseItem":
+                - "LegalDocItem":
+                - "PubChannelItem":
+                - "AutoObjectCatItem":
+                - "AutoCatLabelItem:"
+                - "LanguageCode_ISO639_1":
+            - "References":
                 group: true
                 expanded: false
                 child-nodes:
-                    - "ManCatLabelItem":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_mancatlabelitem"
-                    - "AssetKindItem":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetkinditem"
-                    - "AssetFormatItem":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetformatitem"
-                    - "NatRelItem":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_natrelitem"
-                    - "StatusWorkItem":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_statusworkitem"
-            - "Verknüpfungstabellen":
+                - "ManCatLabelRef":
+                    qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_mancatlabelref"
+                - "AssetKindRef":
+                - "AssetFormatRef":
+                - "NatRelRef":
+                - "StatusWorkRef":
+                - "GeomQualityRef":
+                - "LanguageRef":
+                - "ContactKindRef":
+                - "StatusAssetUseRef":
+                - "LegalDocRef":
+                - "PubChannelRef":
+                - "AutoObjectCatRef":
+                - "AutoCatLabelRef":
+            - "Others":
                 group: true
                 expanded: false
                 child-nodes:
-                    - "AssetItem_Contact_Author":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_contact_author"
-                    - "AssetItem_Contact_Initiator":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_contact_initiator"
-                    - "AssetItem_Contact_Supplier":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_contact_supplier"
-                    - "AssetItem_Publication":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_publication"
-                    - "AssetItem_UsedBy":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_usedby"
-                    - "AssetItemX_AssetItemY":
-                        qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitemx_assetitemy"
+                - "MultilingualMText":
+                - "MultilingualText":
+                - "LocalisedMText":
+                - "LocalisedText":
+        - "Verknüpfungen":
+            group: true
+            expanded: false
+            child-nodes:
+            - "AssetItem_Contact_Author":
+                qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_contact_author"
+            - "AssetItem_Contact_Initiator":
+                qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_contact_initiator"
+            - "AssetItem_Contact_Supplier":
+                qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_contact_supplier"
+            - "AssetItem_Publication":
+                qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_publication"
+            - "AssetItem_UsedBy":
+                qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitem_usedby"
+            - "AssetItemX_AssetItemY":
+                qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_assetitemx_assetitemy"
+        - "Basismodell":
+            group: true
+            expanded: false
+            child-nodes:
+            - "AssetItem (GeolAssets_V2)":
+                iliname: "GeolAssets_V2.GeolAssets.AssetItem"
+            - "Contact (GeolAssets_V2)":
+                iliname: "GeolAssets_V2.GeolAssets.Contact"
+        - "System":
+            group: true
+            expanded: false
+            child-nodes:
+            - "T_ILI2DB_DATASET":
+            - "T_ILI2DB_BASKET":
 
 properties:
     transaction_mode: "AutomaticGroups"

--- a/lg_geolassets_v2/projecttopping/lg_geolassets_v2_gpkg.yaml
+++ b/lg_geolassets_v2/projecttopping/lg_geolassets_v2_gpkg.yaml
@@ -14,6 +14,7 @@ layertree:
     - "StudyLocation":
         iliname: "GeolAssets_V2.GeolAssets.StudyLocation"
         qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_studylocation"
+        checked: false
     - "StudyTrace":
         iliname: "GeolAssets_V2.GeolAssets.StudyTrace"
         qmlstylefile: "ilidata:lg_geolassets_v2.qgis_layerstyle_studytrace"


### PR DESCRIPTION
**Changes:**

- t_ili_tid Unique in den Layern "AssetItem", "Contact", "Publication", "InternalProject", "StudyLocation", "StudyTrace" und "StudyArea" damit die Duplication Funktion stabil funktioniert.

- "Open Form" Button in den Formularen der Geometrielayer "StudyLocation", "StudyTrace" und "Study Area" um von der Geometrie auf den AssetItem zu kommen.

- Reiter in "Contacts": "Supplied Assets", "Initiated Assets", "Authored Assets" um die verlinkten AssetItems anzuzeigen. Sowie zusätzlich die Display Expression 
  ```
  coalesce( attribute(get_feature('AssetItem', 'T_Id', "authoredassetitem_lg_geolssts_v2geolassets_assetitem"),'titlepublic'),'Kein Öffentlicher Titel vorhanden' )
  ```
  (bzw. andere FK Namen) in den Linktabellen: "AssetItem_Contact_Supplier", "AssetItem_Contact_Initiator" und "AssetItem_Contact_Author" und Formularkonfiguration um den AssetItem zu öffnen.

- Reiter in "Publications": "Assets" um die verlinkten AssetItems anzuzeigen. Zusätzlich die Display Expression:
  ```
  coalesce( attribute(get_feature('AssetItem', 'T_Id', "assetitem"),'titlepublic'),'Kein Öffentlicher Titel vorhanden' )
  ```
  in der Linktabelle "AssetItem_Publication" und Formularkonfiguration um den AssetItem zu öffnen.

- Reiter in "InternalProjects": "Assets" um die verlinkten AssetItems anzuzeigen. Zusätzlich die Display Expression:
  ```
  coalesce( attribute(get_feature('AssetItem', 'T_Id', "assetitem"),'titlepublic'),'Kein Öffentlicher Titel vorhanden' )
  ```
  in der Linktabelle "AssetItem_UsedBy" und Formularkonfiguration um den AssetItem zu öffnen.

- Reiter in "NatRelItem": "Assets" um die verlinkten AssetItems anzuzeigen. Zusätzlich die Display Expression:
  ```
  coalesce( attribute(get_feature('AssetItem', 'T_Id', "lg_glssts_vssts_ssttem_typenatrel"),'titlepublic'),'Kein Öffentlicher Titel vorhanden' )
  ```
  in der Linktabelle "TypeNatRel" und Formularkonfiguration um den AssetItem zu öffnen.

- Reiter in "ManCatLabelItem": "Assets" um die verlinkten AssetItems anzuzeigen. Zusätzlich die Display Expression:
  ```
  coalesce( attribute(get_feature('AssetItem', 'T_Id', "assetitem_mancatlabel"),'titlepublic'),'Kein Öffentlicher Titel vorhanden' )
  ```
  in der Linktabelle "ManCatLabelRef" und Formularkonfiguration um den AssetItem zu öffnen. Diese Tabelle muss zusätzlich in den Layertree unter "Strukturtabellen" kommen.

**Update Affected Layers:**
AssetItem
- *Form
StudyLocation, StudyArea und StudyTrace
- *Form
- *Symbology
Contact
- *Form
AssetItem_Contact_Supplier, AssetItem_Contact_Initiator, AssetItem_Contact_Author
- *Form
- *Konfiguration (Disp. Exp)
Publication
- *Form
InternalProjects
- *Form
AssetItem_Publication
- *Form
- *Konfiguration (Disp. Exp)
AssetItem_UsedBy
- *Form
- *Konfiguration (Disp. Exp)
NatRelItem
- *Form
ManCatLabelItem
- *Form
TypeNatRel
- *Form
- *Konfiguration (Disp. Exp)
ManCatLabelRef
- *Form
- *Konfiguration (Disp. Exp)
- Muss in den YAML Tree

**Problem (Resolved):**
Leider gibt es das Problem, dass die Expressions nicht sauber funktionieren. Dies wurde bereits in der Tabelle assetitemx_assetitemy bemerkt. Es geht um das lesen des Layers nach Name "AssetItem" - da nimmt es (scheinbar zufällig) manchmal die des GeolAsset_V2 Modelles und manchmal des LG_GeolAsset_V2. Die Problematik der gleichnamigen Layers wurde bereits hier https://github.com/opengisch/QgisModelBaker/issues/461 diskutiert. Dies soll in ModelBaker gefixt werden.
> Wurde aber nicht im ModelBaker gefixt sondern so im UsabILItyHub: https://github.com/opengisch/models/pull/6#issuecomment-1232795954